### PR TITLE
Close #3: [`orphan-cats`] Add `OrphanCats` and add `CatsFunctor` for `cats.Functor`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,12 @@ lazy val orphan = (project in file("."))
 lazy val orphanCats    = module("cats", crossProject(JVMPlatform, JSPlatform))
   .settings(
     libraryDependencies ++= List(libs.cats.value % Optional) ++ (
-      if (isScala3(scalaVersion.value)) List.empty else List(libs.scalacCompatAnnotation)
+      if (isScala3(scalaVersion.value)) List.empty
+      else
+        List(
+          libs.scalacCompatAnnotation,
+          libs.tests.scalaReflect.value
+        )
     ),
   )
 lazy val orphanCatsJvm = orphanCats.jvm
@@ -124,6 +129,10 @@ lazy val libs = new {
         "qa.hedgehog" %%% "hedgehog-runner" % props.HedgehogVersion,
         "qa.hedgehog" %%% "hedgehog-sbt"    % props.HedgehogVersion,
       ).map(_ % Test)
+    }
+
+    lazy val scalaReflect = Def.setting {
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Test
     }
 
   }

--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsFunctorSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsFunctorSpec.scala
@@ -1,0 +1,36 @@
+package orphan_test
+
+import cats.Functor
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyFunctor}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsFunctorSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyFunctor", testMyFunctor),
+    property("test CatsFunctor", testCatsFunctor),
+  )
+
+  def testMyFunctor: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val expected = MyBox(n * 2)
+    val actual   = MyFunctor[MyBox].map(myBox)(_ * 2)
+    actual ==== expected
+  }
+
+  def testCatsFunctor: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val expected = MyBox(n * 2)
+    val actual   = Functor[MyBox].map(myBox)(_ * 2)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsFunctorSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsFunctorSpec.scala
@@ -1,0 +1,36 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsInstances.{MyBox, MyFunctor}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsFunctorSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyFunctor", testMyFunctor),
+    example("test CatsFunctor", testCatsFunctor),
+  )
+
+  def testMyFunctor: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val expected = MyBox(n * 2)
+    val actual   = MyFunctor[MyBox].map(myBox)(_ * 2)
+    actual ==== expected
+  }
+
+  def testCatsFunctor: Result = {
+    val expected = ExpectedMessages.ExpectedMessageForCatsFunctor
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsInstances.MyBox.catsFunctor"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/ExpectedMessages.scala
@@ -1,0 +1,11 @@
+package orphan_test
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object ExpectedMessages {
+  val ExpectedMessageForCatsFunctor: String =
+    """error: Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided by extras, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt
+      |orphan_instance.OrphanCatsInstances.MyBox.catsFunctor
+      |                                          ^""".stripMargin
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsFunctorSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsFunctorSpec.scala
@@ -1,0 +1,41 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyFunctor}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsFunctorSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyFunctor", testMyFunctor),
+    example("test CatsFunctor", testCatsFunctor),
+  )
+
+  def testMyFunctor: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val expected = MyBox(n * 2)
+    val actual   = MyFunctor[MyBox].map(myBox)(_ * 2)
+    actual ==== expected
+  }
+
+  def testCatsFunctor: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage =
+      """Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided by extras, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCatsInstances.MyBox.catsFunctor
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -1,0 +1,24 @@
+package orphan
+
+import scala.annotation.implicitNotFound
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+trait OrphanCats {
+  final protected type CatsFunctor[F[*[*]]] = OrphanCats.CatsFunctor[F]
+}
+private[orphan] object OrphanCats {
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Functor[F[*]] provided by extras, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsFunctor[F[*[*]]]
+  private[OrphanCats] object CatsFunctor {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsFunctor: CatsFunctor[cats.Functor] =
+      null // scalafix:ok DisableSyntax.null
+  }
+}

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -1,0 +1,24 @@
+package orphan
+
+import scala.annotation.implicitNotFound
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+trait OrphanCats {
+  final protected type CatsFunctor[F[*[*]]] = OrphanCats.CatsFunctor[F]
+}
+private[orphan] object OrphanCats {
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Functor[F[*]] provided by extras, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsFunctor[F[*[*]]]
+  private[OrphanCats] object CatsFunctor {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    inline given getCatsFunctor: CatsFunctor[cats.Functor] =
+      null // scalafix:ok DisableSyntax.null
+  }
+}

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan/testing/CompileTimeError.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan/testing/CompileTimeError.scala
@@ -1,0 +1,8 @@
+package orphan.testing
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CompileTimeError {
+  def from(code: String): String = macro MacroCompileTimeError.fromImpl
+}

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan/testing/MacroCompileTimeError.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan/testing/MacroCompileTimeError.scala
@@ -1,0 +1,51 @@
+package orphan.testing
+
+import scala.annotation.nowarn
+import scala.reflect.macros.ParseException
+import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.blackbox.Context
+
+/** This is from munit's MacroCompatScala2.compileErrorsImpl
+  *   https://github.com/scalameta/munit/blob/effba46e485b718b03ce215835450c7e51a381f0/munit/shared/src/main/scala/munit/internal/MacroCompatScala2.scala#L60-L86
+  * @author Kevin Lee
+  * @since 2025-07-28
+  */
+object MacroCompileTimeError {
+
+  def fromImpl(c: Context)(code: c.Tree): c.Tree = {
+    import c.universe._
+    val toParse: String = code match {
+      case Literal(Constant(literal: String)) => literal
+      case _ =>
+        c.abort(
+          code.pos,
+          "cannot compile dynamic expressions, only constant literals.\n" +
+            "To fix this problem, pass in a string literal in double quotes \"...\"",
+        )
+    }
+
+    @nowarn("msg=deprecated")
+    def formatError(message: String, pos: scala.reflect.api.Position): String =
+      new StringBuilder()
+        .append("error:")
+        .append(if (message.contains('\n')) "\n" else " ")
+        .append(message)
+        .append("\n")
+        .append(pos.lineContent)
+        .append("\n")
+        .append(" " * (pos.column - 1))
+        .append("^")
+        .toString()
+
+    val message: String =
+      try {
+        val _ = c.typecheck(c.parse(s"{\n$toParse\n}"))
+        ""
+      } catch {
+        case e: ParseException => formatError(e.getMessage(), e.pos)
+        case e: TypecheckException => formatError(e.getMessage(), e.pos)
+      }
+    Literal(Constant(message))
+  }
+
+}

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
@@ -1,0 +1,32 @@
+package orphan_instance
+
+import org.typelevel.scalaccompat.annotation.nowarn213
+import orphan.OrphanCats
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object OrphanCatsInstances {
+  trait MyFunctor[F[*]] {
+    def map[A, B](fa: F[A])(f: A => B): F[B]
+  }
+  object MyFunctor {
+    def apply[F[*]: MyFunctor]: MyFunctor[F] = implicitly[MyFunctor[F]]
+  }
+
+  final case class MyBox[A](a: A)
+  object MyBox extends OrphanCats {
+
+    implicit def myboxMyFunctor: MyFunctor[MyBox] = new MyFunctor[MyBox] {
+      override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
+    }
+
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CatsFunctor\[F\] in method catsFunctor is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsFunctor[F[*[*]]: CatsFunctor]: F[MyBox] = new cats.Functor[MyBox] {
+      override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
+    }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+}

--- a/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsInstances.scala
@@ -1,0 +1,33 @@
+package orphan_instance
+
+import orphan.OrphanCats
+
+import scala.annotation.nowarn
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object OrphanCatsInstances {
+  trait MyFunctor[F[*]] {
+    def map[A, B](fa: F[A])(f: A => B): F[B]
+  }
+  object MyFunctor {
+    def apply[F[*]: MyFunctor]: MyFunctor[F] = summon[MyFunctor[F]]
+  }
+
+  final case class MyBox[A](a: A)
+  object MyBox extends OrphanCats {
+
+    given myboxMyFunctor: MyFunctor[MyBox] with {
+      override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
+    }
+
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsFunctor\[F\] in method catsFunctor is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given catsFunctor[F[*[*]]: CatsFunctor]: F[MyBox] = new cats.Functor[MyBox] {
+      override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
+    }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+}


### PR DESCRIPTION
## Close #3: [`orphan-cats`] Add `OrphanCats` and add `CatsFunctor` for `cats.Functor`

Add `OrphanCats` trait with compile-time error handling for missing cats dependency

- Add `OrphanCats` trait for both Scala 2 and 3 with `CatsFunctor` type member
- Implement helpful `@implicitNotFound` messages when cats library is missing
- Add compile-time error testing utilities (`CompileTimeError`, `MacroCompileTimeError`)
- Add test instances (`OrphanCatsInstances`) with `MyBox` and `MyFunctor` examples
- Support both `implicit` (Scala 2) and `given` (Scala 3) syntax patterns