### PR TITLE
Update GitHub Actions: expand build matrix to support multiple Scala versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 2.12", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala 2.13", version: "2.13.13", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala 3",    version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin" }
 
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +31,7 @@ jobs:
           cache: sbt
       - uses: sbt/setup-sbt@v1
 
-      - name: "[Push] Build All for ${{ matrix.scala.name }} - ${{ github.run_number }}"
+      - name: "[Push] Build All for ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: github.event_name == 'push'
         env:
           CURRENT_BRANCH_NAME: ${{ github.ref }}
@@ -46,9 +48,9 @@ jobs:
           java -version
           echo "JVM_OPTS=${JVM_OPTS}"
           echo "SBT_OPTS=${SBT_OPTS}"
-          .github/workflows/sbt-build-all.sh
+          .github/workflows/sbt-build-all-with-scala-version.sh ${{ matrix.scala.version }}
 
-      - name: "[PR] Build All for ${{ matrix.scala.name }} - PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
+      - name: "[PR] Build All for ${{ matrix.scala.name }} ${{ matrix.scala.version }} - PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
         if: github.event_name == 'pull_request'
         env:
           CURRENT_BRANCH_NAME: ${{ github.base_ref }}
@@ -64,4 +66,4 @@ jobs:
           java -version
           echo "JVM_OPTS=${JVM_OPTS}"
           echo "SBT_OPTS=${SBT_OPTS}"
-          .github/workflows/sbt-build-all.sh ${{ matrix.scala.report }}
+          .github/workflows/sbt-build-all-with-scala-version.sh ${{ matrix.scala.version }}


### PR DESCRIPTION
## Update GitHub Actions: expand build matrix to support multiple Scala versions

- Add explicit Scala `2.12.18`, `2.13.13`, and `3.1.3` to build matrix
- Replace generic "Scala" entry with version-specific configurations
- Update build script to use `sbt-build-all-with-scala-version.sh`