### PR TITLE
Close #12: [`orphan-cats`] Add `CatsMonad` for `cats.Monad`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsMonadWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsMonadWithCatsSpec.scala
@@ -1,0 +1,81 @@
+package orphan_test
+
+import cats.Monad
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyMonad}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsMonadWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyMonad.pure", testMyMonadPure),
+    property("test MyMonad.flatMap", testMyMonadFlatMap),
+    property("test cats.Monad.map", testCatsMonadMap),
+    property("test cats.Monad.pure", testCatsMonadPure),
+    property("test cats.Monad.ap", testCatsMonadAp),
+    property("test cats.Monad.flatMap", testCatsMonadFlatMap),
+  )
+
+  def testMyMonadPure: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+  } yield {
+    val expected = MyBox(n)
+    val actual   = MyMonad[MyBox].pure(n)
+    actual ==== expected
+  }
+
+  def testMyMonadFlatMap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val f: Int => MyBox[String] = a => MyBox((a * 2).toString)
+
+    val expected = MyBox((n * 2).toString)
+    val actual   = MyMonad[MyBox].flatMap(myBox)(f)
+    actual ==== expected
+  }
+
+  def testCatsMonadMap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val expected = MyBox(n * 2)
+    val actual   = Monad[MyBox].map(myBox)(_ * 2)
+    actual ==== expected
+  }
+
+  def testCatsMonadPure: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+  } yield {
+    val expected = MyBox(n)
+    val actual   = Monad[MyBox].pure(n)
+    actual ==== expected
+  }
+
+  def testCatsMonadAp: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    f     <- Gen.constant((a: Int) => a * 2).log("f")
+    myBox <- Gen.constant(MyBox(n)).log("myoBox")
+
+    myBoxWithFunction <- Gen.constant(MyBox(f)).log("myBoxWithFunction")
+  } yield {
+    val expected = MyBox(f(n))
+    val actual   = Monad[MyBox].ap(myBoxWithFunction)(myBox)
+    actual ==== expected
+  }
+
+  def testCatsMonadFlatMap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val f: Int => MyBox[String] = a => MyBox((a * 2).toString)
+
+    val expected = MyBox((n * 2).toString)
+    val actual   = Monad[MyBox].flatMap(myBox)(f)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonadWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonadWithoutCatsSpec.scala
@@ -1,0 +1,49 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsInstances.{MyBox, MyMonad}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsMonadWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyMonad.pure", testMyMonadPure),
+    property("test MyMonad.flatMap", testMyMonadFlatMap),
+    example("test CatsMonad", testCatsMonad),
+  )
+
+  def testMyMonadPure: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+  } yield {
+    val expected = MyBox(n)
+    val actual   = MyMonad[MyBox].pure(n)
+    actual ==== expected
+  }
+
+  def testMyMonadFlatMap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val f: Int => MyBox[String] = a => MyBox((a * 2).toString)
+
+    val expected = MyBox((n * 2).toString)
+    val actual   = MyMonad[MyBox].flatMap(myBox)(f)
+    actual ==== expected
+  }
+
+  def testCatsMonad: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsMonad}
+                      |orphan_instance.OrphanCatsInstances.MyBox.catsMonad
+                      |                                          ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsInstances.MyBox.catsMonad"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonadWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonadWithoutCatsSpec.scala
@@ -1,0 +1,51 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyMonad}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsMonadWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyMonad.pure", testMyMonadPure),
+    property("test MyMonad.flatMap", testMyMonadFlatMap),
+    example("test CatsMonad", testCatsMonad),
+  )
+
+  def testMyMonadPure: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+  } yield {
+    val expected = MyBox(n)
+    val actual   = MyMonad[MyBox].pure(n)
+    actual ==== expected
+  }
+
+  def testMyMonadFlatMap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val f: Int => MyBox[String] = a => MyBox((a * 2).toString)
+
+    val expected = MyBox((n * 2).toString)
+    val actual   = MyMonad[MyBox].flatMap(myBox)(f)
+    actual ==== expected
+  }
+
+  def testCatsMonad: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsMonad
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCatsInstances.MyBox.catsMonad
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -10,4 +10,7 @@ object ExpectedMessages {
   val ExpectedMessageForCatsApplicative: String =
     """Missing an instance of `CatsApplicative` which means you're trying to use cats.Applicative, but cats library is missing in your project config. If you want to have an instance of cats.Applicative[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsMonad: String =
+    """Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, but cats library is missing in your project config. If you want to have an instance of cats.Monad[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -8,6 +8,7 @@ import scala.annotation.implicitNotFound
 trait OrphanCats {
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
+  final protected type CatsMonad[F[*[*]]]       = OrphanCats.CatsMonad[F]
 }
 private[orphan] object OrphanCats {
   @implicitNotFound(
@@ -33,6 +34,19 @@ private[orphan] object OrphanCats {
   private[OrphanCats] object CatsApplicative {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsApplicative: CatsApplicative[cats.Applicative] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Monad[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsMonad[F[*[*]]]
+  private[OrphanCats] object CatsMonad {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsMonad: CatsMonad[cats.Monad] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -8,6 +8,7 @@ import scala.annotation.implicitNotFound
 trait OrphanCats {
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
+  final protected type CatsMonad[F[*[*]]]       = OrphanCats.CatsMonad[F]
 }
 private[orphan] object OrphanCats {
   @implicitNotFound(
@@ -19,7 +20,7 @@ private[orphan] object OrphanCats {
   sealed protected trait CatsFunctor[F[*[*]]]
   private[OrphanCats] object CatsFunctor {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
-    inline given getCatsFunctor: CatsFunctor[cats.Functor] =
+    final inline given getCatsFunctor: CatsFunctor[cats.Functor] =
       null // scalafix:ok DisableSyntax.null
   }
 
@@ -32,7 +33,20 @@ private[orphan] object OrphanCats {
   sealed protected trait CatsApplicative[F[*[*]]]
   private[OrphanCats] object CatsApplicative {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
-    inline given getCatsApplicative: CatsApplicative[cats.Applicative] =
+    final inline given getCatsApplicative: CatsApplicative[cats.Applicative] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Monad[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsMonad[F[*[*]]]
+  private[OrphanCats] object CatsMonad {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsMonad: CatsMonad[cats.Monad] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsInstances.scala
@@ -3,6 +3,7 @@ package orphan_instance
 import orphan.OrphanCats
 
 import scala.annotation.nowarn
+import scala.annotation.tailrec
 
 /** @author Kevin Lee
   * @since 2025-07-28
@@ -23,8 +24,17 @@ object OrphanCatsInstances {
     def apply[F[*]: MyApplicative]: MyApplicative[F] = summon[MyApplicative[F]]
   }
 
+  trait MyMonad[F[*]] {
+    def pure[A](a: A): F[A]
+    def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
+    def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B]
+  }
+  object MyMonad {
+    def apply[F[*]: MyMonad]: MyMonad[F] = summon[MyMonad[F]]
+  }
+
   final case class MyBox[A](a: A)
-  object MyBox extends CatsInstances2 {
+  object MyBox extends CatsInstances {
 
     given myBoxMyFunctor: MyFunctor[MyBox] with {
       override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
@@ -36,9 +46,21 @@ object OrphanCatsInstances {
       override def ap[A, B](ff: MyBox[A => B])(fa: MyBox[A]): MyBox[B] = pure(ff.a(fa.a))
     }
 
+    given myBoxMyMonad: MyMonad[MyBox] with {
+      override def pure[A](a: A): MyBox[A] = MyBox(a)
+
+      override def flatMap[A, B](fa: MyBox[A])(f: A => MyBox[B]): MyBox[B] = f(fa.a)
+
+      @tailrec
+      override def tailRecM[A, B](a: A)(f: A => MyBox[Either[A, B]]): MyBox[B] = f(a) match {
+        case MyBox(Right(b)) => pure(b)
+        case MyBox(Left(a)) => tailRecM(a)(f)
+      }
+    }
+
   }
 
-  private[orphan_instance] trait CatsInstances2 extends CatsInstances1 {
+  private[orphan_instance] trait CatsInstances extends CatsInstances1 {
     @nowarn(
       """msg=evidence parameter .+ of type (.+\.)*CatsFunctor\[F\] in method catsFunctor is never used"""
     )
@@ -48,7 +70,7 @@ object OrphanCatsInstances {
     }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
-  private[orphan_instance] trait CatsInstances1 extends OrphanCats {
+  private[orphan_instance] trait CatsInstances1 extends MyCatsInstances2 {
     @nowarn(
       """msg=evidence parameter .+ of type (.+\.)*CatsFunctor\[F\] in method catsFunctor is never used"""
     )
@@ -57,6 +79,24 @@ object OrphanCatsInstances {
       override def pure[A](a: A): MyBox[A] = MyBox(a)
 
       override def ap[A, B](ff: MyBox[A => B])(fa: MyBox[A]): MyBox[B] = pure(ff.a(fa.a))
+    }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsInstances2 extends OrphanCats {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsMonad\[F\] in method catsMonad is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given catsMonad[F[*[*]]: CatsMonad]: F[MyBox] = new cats.Monad[MyBox] {
+      override def pure[A](x: A): MyBox[A] = MyBox(x)
+
+      override def flatMap[A, B](fa: MyBox[A])(f: A => MyBox[B]): MyBox[B] = f(fa.a)
+
+      @tailrec
+      override def tailRecM[A, B](a: A)(f: A => MyBox[Either[A, B]]): MyBox[B] = f(a) match {
+        case MyBox(Right(b)) => pure(b)
+        case MyBox(Left(a)) => tailRecM(a)(f)
+      }
     }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 


### PR DESCRIPTION
## Close #12: [`orphan-cats`] Add `CatsMonad` for `cats.Monad`

- Add `CatsMonad` trait with `@implicitNotFound` annotation for missing cats-core dependency
- Add `final` modifier to existing `inline` `given` (type-classes) for `CatsFunctor` and `CatsApplicative`
- Add `MyMonad` trait and instances for test code in both Scala 2 and 3
- Implement `tailRecM` method with `@tailrec` annotation for stack safety
- Reorganize `trait` hierarchy to support new `Monad` instances
- Add `cats.Monad` instance for `MyBox` test type