### PR TITLE
Close #14: [`orphan-cats`] Add `CatsSemigroup` for `cats.kernel.Semigroup`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsSemigroupWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsSemigroupWithCatsSpec.scala
@@ -1,0 +1,40 @@
+package orphan_test
+
+import cats.Semigroup
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyNum, MySemigroup}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsSemigroupWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MySemigroup.combine", testMySemigroupCombine),
+    property("test CatsSemigroup.combine", testCatsSemigroupCombine),
+  )
+
+  def testMySemigroupCombine: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = MySemigroup[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsSemigroupCombine: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = Semigroup[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsSemigroupWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsSemigroupWithoutCatsSpec.scala
@@ -1,0 +1,40 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsKernelInstances.{MyNum, MySemigroup}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsSemigroupWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MySemigroup.combine", testMySemigroupMap),
+    example("test CatsSemigroup.combine", testCatsSemigroup),
+  )
+
+  def testMySemigroupMap: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = MySemigroup[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsSemigroup: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsSemigroup}
+                      |orphan_instance.OrphanCatsKernelInstances.MyNum.catsSemigroup
+                      |                                                ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsKernelInstances.MyNum.catsSemigroup"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsSemigroupWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsSemigroupWithoutCatsSpec.scala
@@ -1,0 +1,45 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyNum, MySemigroup}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsSemigroupWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MySemigroup.combine", testMySemigroupMap),
+    example("test CatsSemigroup.combine", testCatsSemigroup),
+  )
+
+  def testMySemigroupMap: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = MySemigroup[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsSemigroup: Result = {
+
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsSemigroup
+
+    val actual = typeCheckErrors(
+      """
+        val _ = orphan_instance.OrphanCatsKernelInstances.MyNum.catsSemigroup
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual error message doesn't start with the expected one.")
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -13,4 +13,7 @@ object ExpectedMessages {
   val ExpectedMessageForCatsMonad: String =
     """Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, but cats library is missing in your project config. If you want to have an instance of cats.Monad[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsSemigroup: String =
+    """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -1,0 +1,26 @@
+package orphan
+
+import scala.annotation.implicitNotFound
+
+/** @author Kevin Lee
+  * @since 2025-08-02
+  */
+trait OrphanCatsKernel {
+  final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
+}
+private[orphan] object OrphanCatsKernel {
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsSemigroup[F[*]]
+  private[OrphanCatsKernel] object CatsSemigroup {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsSemigroup: CatsSemigroup[cats.kernel.Semigroup] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+}

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -1,0 +1,26 @@
+package orphan
+
+import scala.annotation.implicitNotFound
+
+/** @author Kevin Lee
+  * @since 2025-08-02
+  */
+trait OrphanCatsKernel {
+  final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
+}
+private[orphan] object OrphanCatsKernel {
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsSemigroup[F[*]]
+  private[OrphanCatsKernel] object CatsSemigroup {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsSemigroup: CatsSemigroup[cats.kernel.Semigroup] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+}

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
@@ -1,0 +1,35 @@
+package orphan_instance
+
+import org.typelevel.scalaccompat.annotation.nowarn213
+import orphan.OrphanCatsKernel
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object OrphanCatsKernelInstances {
+
+  trait MySemigroup[A] {
+    def combine(x: A, y: A): A
+  }
+  object MySemigroup {
+    def apply[A: MySemigroup]: MySemigroup[A] = implicitly[MySemigroup[A]]
+  }
+
+  final case class MyNum(n: Int)
+  object MyNum extends MyCatsInstances {
+    implicit def myNumMySemigroup: MySemigroup[MyNum] = new MySemigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }
+  }
+
+  private[orphan_instance] trait MyCatsInstances extends OrphanCatsKernel {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CatsSemigroup\[F\] in method catsSemigroup is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsSemigroup[F[*]: CatsSemigroup]: F[MyNum] = new cats.kernel.Semigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+}

--- a/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsKernelInstances.scala
@@ -1,0 +1,36 @@
+package orphan_instance
+
+import orphan.OrphanCatsKernel
+
+import scala.annotation.nowarn
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object OrphanCatsKernelInstances {
+
+  trait MySemigroup[A] {
+    def combine(x: A, y: A): A
+  }
+  object MySemigroup {
+    def apply[A: MySemigroup]: MySemigroup[A] = summon[MySemigroup[A]]
+  }
+
+  final case class MyNum(n: Int)
+  object MyNum extends MyCatsInstances {
+    implicit def myNumMySemigroup: MySemigroup[MyNum] = new MySemigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }
+  }
+
+  private[orphan_instance] trait MyCatsInstances extends OrphanCatsKernel {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsSemigroup\[F\] in method catsSemigroup is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given catsSemigroup[F[*]: CatsSemigroup]: F[MyNum] = new cats.kernel.Semigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+}


### PR DESCRIPTION
Close #14: [`orphan-cats`] Add `CatsSemigroup` for `cats.kernel.Semigroup`

- Add `OrphanCatsKernel` trait with `CatsSemigroup` type alias and `@implicitNotFound` annotation
- Implement `CatsSemigroup` instances for both Scala 2 and Scala 3 - Not actual instances but to make an instance of `cats.kernel.Semigroup` type-class check if `cats` is available.
- Add `OrphanCatsKernelInstances` with `MySemigroup` `trait` and `MyNum` case class for testing
- Add comprehensive test coverage in `CatsSemigroupWithoutCatsSpec`
- Add expected error message for missing `cats.kernel.Semigroup` dependency to ensure proper compile-time error when cats library is not available