### PR TITLE
Close #15: [`orphan-cats`] Add `CatsMonoid` for `cats.kernel.Monoid`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsMonoidWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsMonoidWithCatsSpec.scala
@@ -1,0 +1,56 @@
+package orphan_test
+
+import cats.Monoid
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyMonoid, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsMonoidWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("test MyMonoid.empty", testMyMonoidEmpty),
+    property("test MyMonoid.combine", testMyMonoidCombine),
+    example("test CatsMonoid.empty", testCatsMonoidEmpty),
+    property("test CatsMonoid.combine", testCatsMonoidCombine),
+  )
+
+  def testMyMonoidEmpty: Result = {
+    val expected = MyNum(0)
+    val actual   = MyMonoid[MyNum].empty
+
+    actual ==== expected
+  }
+
+  def testMyMonoidCombine: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = MyMonoid[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsMonoidEmpty: Result = {
+    val expected = MyNum(0)
+    val actual   = Monoid[MyNum].empty
+
+    actual ==== expected
+  }
+
+  def testCatsMonoidCombine: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = Monoid[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonoidWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonoidWithoutCatsSpec.scala
@@ -1,0 +1,48 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsKernelInstances.{MyMonoid, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsMonoidWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("test MyMonoid.empty", testMyMonoidEmpty),
+    property("test MyMonoid.combine", testMyMonoidCombine),
+    example("test CatsMonoid", testCatsMonoid),
+  )
+
+  def testMyMonoidEmpty: Result = {
+    val expected = MyNum(0)
+    val actual   = MyMonoid[MyNum].empty
+
+    actual ==== expected
+  }
+
+  def testMyMonoidCombine: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = MyMonoid[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsMonoid: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsMonoid}
+                      |orphan_instance.OrphanCatsKernelInstances.MyNum.catsMonoid
+                      |                                                ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsKernelInstances.MyNum.catsMonoid"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonoidWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonoidWithoutCatsSpec.scala
@@ -1,0 +1,53 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyMonoid, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsMonoidWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("test MyMonoid.empty", testMyMonoidEmpty),
+    property("test MyMonoid.combine", testMyMonoidCombine),
+    example("test CatsMonoid", testCatsMonoid),
+  )
+
+  def testMyMonoidEmpty: Result = {
+    val expected = MyNum(0)
+    val actual   = MyMonoid[MyNum].empty
+
+    actual ==== expected
+  }
+
+  def testMyMonoidCombine: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = MyNum(n1 + n2)
+    val actual   = MyMonoid[MyNum].combine(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsMonoid: Result = {
+
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsMonoid
+
+    val actual = typeCheckErrors(
+      """
+        val _ = orphan_instance.OrphanCatsKernelInstances.MyNum.catsMonoid
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual error message doesn't start with the expected one.")
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -16,4 +16,7 @@ object ExpectedMessages {
   val ExpectedMessageForCatsSemigroup: String =
     """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsMonoid: String =
+    """Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Monoid[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -7,6 +7,7 @@ import scala.annotation.implicitNotFound
   */
 trait OrphanCatsKernel {
   final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
+  final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -20,6 +21,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsSemigroup {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsSemigroup: CatsSemigroup[cats.kernel.Semigroup] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Monoid[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsMonoid[F[*]]
+  private[OrphanCatsKernel] object CatsMonoid {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsMonoid: CatsMonoid[cats.kernel.Monoid] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -7,6 +7,7 @@ import scala.annotation.implicitNotFound
   */
 trait OrphanCatsKernel {
   final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
+  final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -20,6 +21,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsSemigroup {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsSemigroup: CatsSemigroup[cats.kernel.Semigroup] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Monoid[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsMonoid[F[*]]
+  private[OrphanCatsKernel] object CatsMonoid {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsMonoid: CatsMonoid[cats.kernel.Monoid] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
@@ -15,19 +15,45 @@ object OrphanCatsKernelInstances {
     def apply[A: MySemigroup]: MySemigroup[A] = implicitly[MySemigroup[A]]
   }
 
+  trait MyMonoid[A] {
+    def empty: A
+    def combine(x: A, y: A): A
+  }
+  object MyMonoid {
+    def apply[A: MyMonoid]: MyMonoid[A] = implicitly[MyMonoid[A]]
+  }
+
   final case class MyNum(n: Int)
-  object MyNum extends MyCatsInstances {
+  object MyNum extends MyCatsKernelInstances {
     implicit def myNumMySemigroup: MySemigroup[MyNum] = new MySemigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }
+
+    implicit def myNumMonoid: MyMonoid[MyNum] = new MyMonoid[MyNum] {
+      override def empty: MyNum = MyNum(0)
+
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
     }
   }
 
-  private[orphan_instance] trait MyCatsInstances extends OrphanCatsKernel {
+  private[orphan_instance] trait MyCatsKernelInstances extends MyCatsKernelInstances1 {
     @nowarn213(
       """msg=evidence parameter .+ of type (.+\.)*CatsSemigroup\[F\] in method catsSemigroup is never used"""
     )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsSemigroup[F[*]: CatsSemigroup]: F[MyNum] = new cats.kernel.Semigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsKernelInstances1 extends OrphanCatsKernel {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CatsMonoid\[F\] in method catsMonoid is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsMonoid[F[*]: CatsMonoid]: F[MyNum] = new cats.kernel.Monoid[MyNum] {
+      override def empty: MyNum = MyNum(0)
+
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
     }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
   }

--- a/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsKernelInstances.scala
@@ -16,19 +16,45 @@ object OrphanCatsKernelInstances {
     def apply[A: MySemigroup]: MySemigroup[A] = summon[MySemigroup[A]]
   }
 
+  trait MyMonoid[A] {
+    def empty: A
+    def combine(x: A, y: A): A
+  }
+  object MyMonoid {
+    def apply[A: MyMonoid]: MyMonoid[A] = summon[MyMonoid[A]]
+  }
+
   final case class MyNum(n: Int)
-  object MyNum extends MyCatsInstances {
-    implicit def myNumMySemigroup: MySemigroup[MyNum] = new MySemigroup[MyNum] {
+  object MyNum extends MyCatsKernelInstances {
+    given myNumMySemigroup: MySemigroup[MyNum] with {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }
+
+    given myNumMonoid: MyMonoid[MyNum] with {
+      override def empty: MyNum = MyNum(0)
+
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
     }
   }
 
-  private[orphan_instance] trait MyCatsInstances extends OrphanCatsKernel {
+  private[orphan_instance] trait MyCatsKernelInstances extends MyCatsKernelInstances1 {
     @nowarn(
       """msg=evidence parameter .+ of type (.+\.)*CatsSemigroup\[F\] in method catsSemigroup is never used"""
     )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     given catsSemigroup[F[*]: CatsSemigroup]: F[MyNum] = new cats.kernel.Semigroup[MyNum] {
+      override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsKernelInstances1 extends OrphanCatsKernel {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsMonoid\[F\] in method catsMonoid is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given catsMonoid[F[*]: CatsMonoid]: F[MyNum] = new cats.kernel.Monoid[MyNum] {
+      override def empty: MyNum = MyNum(0)
+
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
     }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
   }


### PR DESCRIPTION
Close #15: [`orphan-cats`] Add `CatsMonoid` for `cats.kernel.Monoid`

- Add `OrphanCatsKernel` trait with `CatsMonoid` type alias and `@implicitNotFound` annotation
- Implement `CatsMonoid` instances for both Scala 2 and Scala 3 - Not actual instances but to make an instance of `cats.kernel.Monoid` type-class check if `cats` is available.
- Add `OrphanCatsKernelInstances` with `MyMonoid` `trait` and `MyNum` case class for testing
- Add comprehensive test coverage in `CatsMonoidWithoutCatsSpec`
- Add expected error message for missing `cats.kernel.Monoid` dependency to ensure proper compile-time error when cats library is not available