### PR TITLE
Close #20: [`orphan-cats`] Add `CatsTraverse` for `cats.Traverse`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsTraverseWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsTraverseWithCatsSpec.scala
@@ -1,0 +1,96 @@
+package orphan_test
+
+import cats.{Eval, Traverse}
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyApplicative, MyBox, MyEval, MyTraverse}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsTraverseWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyTraverse.traverse", testMyTraverseTraverse),
+    property("test MyTraverse.foldLeft", testMyTraverseFoldLeft),
+    property("test MyTraverse.foldRight", testMyTraverseFoldRight),
+    property("test cats.Traverse.traverse", testCatsTraverseTraverse),
+    property("test cats.Traverse.foldLeft", testCatsTraverseFoldLeft),
+    property("test cats.Traverse.foldRight", testCatsTraverseFoldRight),
+  )
+
+  implicit def optionApplicative: MyApplicative[Option] = new MyApplicative[Option] {
+    override def pure[A](a: A): Option[A] = Some(a)
+
+    override def ap[A, B](ff: Option[A => B])(fa: Option[A]): Option[B] = fa.flatMap(a => ff.map(_(a)))
+  }
+
+  def testMyTraverseTraverse: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    f <- Gen
+           .constant(if (n > 300) (a: Int) => Some(a * 2) else (_: Int) => None)
+           .log("f: Int => Option[Int] where it's Some(Int) if the given Int > 300. Otherwise it's None.")
+  } yield {
+    val input = MyBox(n)
+
+    val expected = Some(MyBox(n * 2))
+    val actual   = MyTraverse[MyBox].traverse(input)(f)
+
+    actual ==== expected
+  }
+
+  def testMyTraverseFoldLeft: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n2 - n1
+    val actual   = MyTraverse[MyBox].foldLeft(myBox, n2)((b, a) => b - a)
+    actual ==== expected
+  }
+
+  def testMyTraverseFoldRight: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n1 - n2
+    val actual   = MyTraverse[MyBox].foldRight(myBox, MyEval(n2))((a, myEvalB) => MyEval(a - myEvalB.thunk()))
+    actual.thunk() ==== expected
+  }
+
+  def testCatsTraverseTraverse: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    f <- Gen
+           .constant(if (n > 300) (a: Int) => Some(a * 2) else (_: Int) => None)
+           .log("f: Int => Option[Int] where it's Some(Int) if the given Int > 300. Otherwise it's None.")
+  } yield {
+    val input = MyBox(n)
+
+    val expected = Some(MyBox(n * 2))
+    val actual   = Traverse[MyBox].traverse(input)(f)
+
+    actual ==== expected
+  }
+
+  def testCatsTraverseFoldLeft: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n2 - n1
+    val actual   = Traverse[MyBox].foldLeft(myBox, n2)((b, a) => b - a)
+    actual ==== expected
+  }
+
+  def testCatsTraverseFoldRight: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n1 - n2
+    val actual   = Traverse[MyBox].foldRight(myBox, Eval.now(n2))((a, myEvalB) => Eval.now(a - myEvalB.value))
+    actual.value ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsTraverseWithCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsTraverseWithCatsSpec.scala
@@ -1,0 +1,71 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsInstances.{MyApplicative, MyBox, MyEval, MyTraverse}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsTraverseWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyTraverse.traverse", testMyTraverseTraverse),
+    property("test MyTraverse.foldLeft", testMyTraverseFoldLeft),
+    property("test MyTraverse.foldRight", testMyTraverseFoldRight),
+    example("test cats.Traverse", testCatsTraverse),
+  )
+
+  implicit def optionApplicative: MyApplicative[Option] = new MyApplicative[Option] {
+    override def pure[A](a: A): Option[A] = Some(a)
+
+    override def ap[A, B](ff: Option[A => B])(fa: Option[A]): Option[B] = fa.flatMap(a => ff.map(_(a)))
+  }
+
+  def testMyTraverseTraverse: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    f <- Gen
+           .constant(if (n > 300) (a: Int) => Some(a * 2) else (_: Int) => None)
+           .log("f: Int => Option[Int] where it's Some(Int) if the given Int > 300. Otherwise it's None.")
+  } yield {
+    val input = MyBox(n)
+
+    val expected = Some(MyBox(n * 2))
+    val actual   = MyTraverse[MyBox].traverse(input)(f)
+
+    actual ==== expected
+  }
+
+  def testMyTraverseFoldLeft: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n2 - n1
+    val actual   = MyTraverse[MyBox].foldLeft(myBox, n2)((b, a) => b - a)
+    actual ==== expected
+  }
+
+  def testMyTraverseFoldRight: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n1 - n2
+    val actual   = MyTraverse[MyBox].foldRight(myBox, MyEval(n2))((a, myEvalB) => MyEval(a - myEvalB.thunk()))
+    actual.thunk() ==== expected
+  }
+
+  def testCatsTraverse: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsTraverse}
+                      |orphan_instance.OrphanCatsInstances.MyBox.catsTraverse
+                      |                                          ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsInstances.MyBox.catsTraverse"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsTraverseWithCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsTraverseWithCatsSpec.scala
@@ -1,0 +1,74 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyApplicative, MyBox, MyEval, MyTraverse}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsTraverseWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyTraverse.traverse", testMyTraverseTraverse),
+    property("test MyTraverse.foldLeft", testMyTraverseFoldLeft),
+    property("test MyTraverse.foldRight", testMyTraverseFoldRight),
+    example("test cats.Traverse", testCatsTraverse),
+  )
+
+  given optionApplicative: MyApplicative[Option] with {
+    override def pure[A](a: A): Option[A] = Some(a)
+
+    override def ap[A, B](ff: Option[A => B])(fa: Option[A]): Option[B] = fa.flatMap(a => ff.map(_(a)))
+  }
+
+  def testMyTraverseTraverse: Property = for {
+    n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    f <- Gen
+           .constant(if (n > 300) (a: Int) => Some(a * 2) else (_: Int) => None)
+           .log("f: Int => Option[Int] where it's Some(Int) if the given Int > 300. Otherwise it's None.")
+  } yield {
+    val input = MyBox(n)
+
+    val expected = Some(MyBox(n * 2))
+    val actual   = MyTraverse[MyBox].traverse(input)(f)
+
+    actual ==== expected
+  }
+
+  def testMyTraverseFoldLeft: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n2 - n1
+    val actual   = MyTraverse[MyBox].foldLeft(myBox, n2)((b, a) => b - a)
+    actual ==== expected
+  }
+
+  def testMyTraverseFoldRight: Property = for {
+    n1    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2    <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myBox <- Gen.constant(MyBox(n1)).log("myBox")
+  } yield {
+    val expected = n1 - n2
+    val actual   = MyTraverse[MyBox].foldRight(myBox, MyEval(n2))((a, myEvalB) => MyEval(a - myEvalB.thunk()))
+    actual.thunk() ==== expected
+  }
+
+  def testCatsTraverse: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsTraverse
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCatsInstances.MyBox.catsTraverse
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -13,6 +13,9 @@ object ExpectedMessages {
   val ExpectedMessageForCatsMonad: String =
     """Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, but cats library is missing in your project config. If you want to have an instance of cats.Monad[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsTraverse: String =
+    """Missing an instance of `CatsTraverse` which means you're trying to use cats.Traverse, but cats library is missing in your project config. If you want to have an instance of cats.Traverse[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
   val ExpectedMessageForCatsSemigroup: String =
     """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -9,6 +9,7 @@ trait OrphanCats {
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
   final protected type CatsMonad[F[*[*]]]       = OrphanCats.CatsMonad[F]
+  final protected type CatsTraverse[F[*[*]]]    = OrphanCats.CatsTraverse[F]
 }
 private[orphan] object OrphanCats {
   @implicitNotFound(
@@ -47,6 +48,19 @@ private[orphan] object OrphanCats {
   private[OrphanCats] object CatsMonad {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsMonad: CatsMonad[cats.Monad] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsTraverse` which means you're trying to use cats.Traverse, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Traverse[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsTraverse[F[*[*]]]
+  private[OrphanCats] object CatsTraverse {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsTraverse: CatsTraverse[cats.Traverse] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -9,6 +9,7 @@ trait OrphanCats {
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
   final protected type CatsMonad[F[*[*]]]       = OrphanCats.CatsMonad[F]
+  final protected type CatsTraverse[F[*[*]]]    = OrphanCats.CatsTraverse[F]
 }
 private[orphan] object OrphanCats {
   @implicitNotFound(
@@ -47,6 +48,19 @@ private[orphan] object OrphanCats {
   private[OrphanCats] object CatsMonad {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsMonad: CatsMonad[cats.Monad] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsTraverse` which means you're trying to use cats.Traverse, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Traverse[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsTraverse[F[*[*]]]
+  private[OrphanCats] object CatsTraverse {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsTraverse: CatsTraverse[cats.Traverse] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
@@ -34,6 +34,20 @@ object OrphanCatsInstances {
     def apply[F[*]: MyMonad]: MyMonad[F] = implicitly[MyMonad[F]]
   }
 
+  class MyEval[A](val thunk: () => A) extends AnyVal
+  object MyEval {
+    def apply[A](a: => A): MyEval[A] = new MyEval[A](() => a)
+  }
+
+  trait MyTraverse[F[*]] {
+    def traverse[G[_]: MyApplicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
+    def foldLeft[A, B](fa: F[A], b: B)(f: (B, A) => B): B
+    def foldRight[A, B](fa: F[A], lb: MyEval[B])(f: (A, MyEval[B]) => MyEval[B]): MyEval[B]
+  }
+  object MyTraverse {
+    def apply[F[*]: MyTraverse]: MyTraverse[F] = implicitly[MyTraverse[F]]
+  }
+
   final case class MyBox[A](a: A)
   object MyBox extends MyCatsInstances {
 
@@ -57,6 +71,16 @@ object OrphanCatsInstances {
         case MyBox(Right(b)) => pure(b)
         case MyBox(Left(a)) => tailRecM(a)(f)
       }
+    }
+
+    implicit def myBoxMyTraverse: MyTraverse[MyBox] = new MyTraverse[MyBox] {
+      override def traverse[G[_]: MyApplicative, A, B](fa: MyBox[A])(f: A => G[B]): G[MyBox[B]] =
+        MyApplicative[G].map(f(fa.a))(MyBox(_))
+
+      override def foldLeft[A, B](fa: MyBox[A], b: B)(f: (B, A) => B): B = f(b, fa.a)
+
+      override def foldRight[A, B](fa: MyBox[A], lb: MyEval[B])(f: (A, MyEval[B]) => MyEval[B]): MyEval[B] =
+        f(fa.a, lb)
     }
 
   }
@@ -83,7 +107,7 @@ object OrphanCatsInstances {
     }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
-  private[orphan_instance] trait MyCatsInstances2 extends OrphanCats {
+  private[orphan_instance] trait MyCatsInstances2 extends MyCatsInstances3 {
     @nowarn213(
       """msg=evidence parameter .+ of type (.+\.)*CatsMonad\[F\] in method catsMonad is never used"""
     )
@@ -98,6 +122,22 @@ object OrphanCatsInstances {
         case MyBox(Right(b)) => pure(b)
         case MyBox(Left(a)) => tailRecM(a)(f)
       }
+    }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsInstances3 extends OrphanCats {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CatsTraverse\[F\] in method catsTraverse is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsTraverse[F[*[*]]: CatsTraverse]: F[MyBox] = new cats.Traverse[MyBox] {
+      override def traverse[G[_]: cats.Applicative, A, B](fa: MyBox[A])(f: A => G[B]): G[MyBox[B]] =
+        cats.Applicative[G].map(f(fa.a))(MyBox(_))
+
+      override def foldLeft[A, B](fa: MyBox[A], b: B)(f: (B, A) => B): B = f(b, fa.a)
+
+      override def foldRight[A, B](fa: MyBox[A], lb: cats.Eval[B])(f: (A, cats.Eval[B]) => cats.Eval[B]): cats.Eval[B] =
+        f(fa.a, lb)
     }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 


### PR DESCRIPTION
Close #20: [`orphan-cats`] Add `CatsTraverse` for `cats.Traverse`

- Add `CatsTraverse` type alias and `@implicitNotFound` annotation to `OrphanCats` for both Scala 2 and 3.
- Add expected error message for missing `CatsTraverse` instance.
- Add `MyEval` and `MyTraverse` `trait`s to test infrastructure.
- Add `MyTraverse` instance for `MyBox` with `traverse`, `foldLeft`, and `foldRight` implementations for testing.
- Add expected error message for missing `cats.Traverse` dependency to ensure proper compile-time error when cats library is not available.