### PR TITLE
Fix `implicitNotFound` messages for `CatsSemigroup` and `CatsMonoid`

### DIFF
--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -17,9 +17,9 @@ object ExpectedMessages {
     """Missing an instance of `CatsTraverse` which means you're trying to use cats.Traverse, but cats library is missing in your project config. If you want to have an instance of cats.Traverse[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
   val ExpectedMessageForCatsSemigroup: String =
-    """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+    """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Semigroup[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
   val ExpectedMessageForCatsMonoid: String =
-    """Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Monoid[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+    """Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Monoid[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -14,7 +14,7 @@ private[orphan] object OrphanCatsKernel {
   @implicitNotFound(
     msg = "Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, " +
       "but cats library is missing in your project config. " +
-      "If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, " +
+      "If you want to have an instance of cats.kernel.Semigroup[A] provided, " +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
   )
   sealed protected trait CatsSemigroup[F[*]]
@@ -27,7 +27,7 @@ private[orphan] object OrphanCatsKernel {
   @implicitNotFound(
     msg = "Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, " +
       "but cats library is missing in your project config. " +
-      "If you want to have an instance of cats.kernel.Monoid[F[*]] provided, " +
+      "If you want to have an instance of cats.kernel.Monoid[A] provided, " +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
   )
   sealed protected trait CatsMonoid[F[*]]

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -14,7 +14,7 @@ private[orphan] object OrphanCatsKernel {
   @implicitNotFound(
     msg = "Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, " +
       "but cats library is missing in your project config. " +
-      "If you want to have an instance of cats.kernel.Semigroup[F[*]] provided, " +
+      "If you want to have an instance of cats.kernel.Semigroup[A] provided, " +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
   )
   sealed protected trait CatsSemigroup[F[*]]
@@ -27,7 +27,7 @@ private[orphan] object OrphanCatsKernel {
   @implicitNotFound(
     msg = "Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, " +
       "but cats library is missing in your project config. " +
-      "If you want to have an instance of cats.kernel.Monoid[F[*]] provided, " +
+      "If you want to have an instance of cats.kernel.Monoid[A] provided, " +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
   )
   sealed protected trait CatsMonoid[F[*]]


### PR DESCRIPTION
Fix `implicitNotFound` messages for `CatsSemigroup` and `CatsMonoid`