### PR TITLE
Close #23: [orphan-cats] Add CatsEq for cats.kernel.Eq

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsEqWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsEqWithCatsSpec.scala
@@ -1,0 +1,64 @@
+package orphan_test
+
+import cats.Eq
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyEq, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsEqWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("MyEq.eqv(A, A) should return true", testMyEqEqvTrue),
+    property("MyEq.eqv(A, A) should return false", testMyEqEqvFalse),
+    property("cats.Eq.eqv(A, A) should return true", testCatsEqEqvTrue),
+    property("cats.Eq.eqv(A, A) should return false", testCatsEqEqvFalse),
+  )
+
+  def testMyEqEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = MyEq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testMyEqEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = MyEq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsEqEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = Eq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testCatsEqEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = Eq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsEqWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsEqWithoutCatsSpec.scala
@@ -1,0 +1,52 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsKernelInstances.{MyEq, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsEqWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("MyEq.eqv(A, A) should return true", testMyEqEqvTrue),
+    property("MyEq.eqv(A, A) should return false", testMyEqEqvFalse),
+    example("test cats.Eq", testCatsEq),
+  )
+
+  def testMyEqEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = MyEq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testMyEqEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = MyEq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsEq: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsEq}
+                      |orphan_instance.OrphanCatsKernelInstances.MyNum.catsEq
+                      |                                                ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsKernelInstances.MyNum.catsEq"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsEqWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsEqWithoutCatsSpec.scala
@@ -1,0 +1,57 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyEq, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsEqWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("MyEq.eqv(A, A) should return true", testMyEqEqvTrue),
+    property("MyEq.eqv(A, A) should return false", testMyEqEqvFalse),
+    example("test cats.Eq", testCatsEq),
+  )
+
+  def testMyEqEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = MyEq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testMyEqEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = MyEq[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsEq: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsEq
+
+    val actual = typeCheckErrors(
+      """
+        val _ = orphan_instance.OrphanCatsKernelInstances.MyNum.catsEq
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual error message doesn't start with the expected one.")
+
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -22,4 +22,7 @@ object ExpectedMessages {
   val ExpectedMessageForCatsMonoid: String =
     """Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Monoid[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsEq: String =
+    """Missing an instance of `CatsEq` which means you're trying to use cats.kernel.Eq, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Eq[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -8,6 +8,7 @@ import scala.annotation.implicitNotFound
 trait OrphanCatsKernel {
   final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
   final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
+  final protected type CatsEq[F[*]]        = OrphanCatsKernel.CatsEq[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -34,6 +35,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsMonoid {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsMonoid: CatsMonoid[cats.kernel.Monoid] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsEq` which means you're trying to use cats.kernel.Eq, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Eq[A] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsEq[F[*]]
+  private[OrphanCatsKernel] object CatsEq {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsEq: CatsEq[cats.kernel.Eq] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -8,6 +8,7 @@ import scala.annotation.implicitNotFound
 trait OrphanCatsKernel {
   final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
   final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
+  final protected type CatsEq[F[*]]        = OrphanCatsKernel.CatsEq[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -34,6 +35,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsMonoid {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsMonoid: CatsMonoid[cats.kernel.Monoid] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsEq` which means you're trying to use cats.kernel.Eq, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Eq[A] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsEq[F[*]]
+  private[OrphanCatsKernel] object CatsEq {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsEq: CatsEq[cats.kernel.Eq] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
@@ -23,6 +23,13 @@ object OrphanCatsKernelInstances {
     def apply[A: MyMonoid]: MyMonoid[A] = implicitly[MyMonoid[A]]
   }
 
+  trait MyEq[A] {
+    def eqv(x: A, y: A): Boolean
+  }
+  object MyEq {
+    def apply[A: MyEq]: MyEq[A] = implicitly[MyEq[A]]
+  }
+
   final case class MyNum(n: Int)
   object MyNum extends MyCatsKernelInstances {
     implicit def myNumMySemigroup: MySemigroup[MyNum] = new MySemigroup[MyNum] {
@@ -34,6 +41,12 @@ object OrphanCatsKernelInstances {
 
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
     }
+
+    implicit def myNumMyEq: MyEq[MyNum] = new MyEq[MyNum] {
+      @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+      override def eqv(x: MyNum, y: MyNum): Boolean = x == y
+    }
+
   }
 
   private[orphan_instance] trait MyCatsKernelInstances extends MyCatsKernelInstances1 {
@@ -46,7 +59,7 @@ object OrphanCatsKernelInstances {
     }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
-  private[orphan_instance] trait MyCatsKernelInstances1 extends OrphanCatsKernel {
+  private[orphan_instance] trait MyCatsKernelInstances1 extends MyCatsKernelInstances2 {
     @nowarn213(
       """msg=evidence parameter .+ of type (.+\.)*CatsMonoid\[F\] in method catsMonoid is never used"""
     )
@@ -55,6 +68,16 @@ object OrphanCatsKernelInstances {
       override def empty: MyNum = MyNum(0)
 
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
+    }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsKernelInstances2 extends OrphanCatsKernel {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CatsEq\[F\] in method catsEq is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsEq[F[*]: CatsEq]: F[MyNum] = new cats.kernel.Eq[MyNum] {
+      override def eqv(x: MyNum, y: MyNum): Boolean = cats.kernel.Eq[Int].eqv(x.n, y.n)
     }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 


### PR DESCRIPTION
Close #23: [`orphan-cats`] Add `CatsEq` for `cats.kernel.Eq`

- Add `CatsEq` type alias and `@implicitNotFound` annotation to `OrphanCatsKernel` for both Scala 2 and 3, including `@implicitNotFound` annotation with helpful error message for missing cats-core dependency
- Add `MyEq` `trait` and `instance`s in test code