### PR TITLE
Close #25: [`orphan-cats`] Add `CatsHash` for `cats.kernel.Hash`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsHashWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsHashWithCatsSpec.scala
@@ -1,0 +1,84 @@
+package orphan_test
+
+import cats.Hash
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyHash, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsHashWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("MyHash.hash(A) should return hash", testMyHashHash),
+    property("MyHash.eqv(A, A) should return true", testMyHashEqvTrue),
+    property("MyHash.eqv(A, A) should return false", testMyHashEqvFalse),
+    property("cats.Hash.hash(A) should return hash", testCatsHashHash),
+    property("cats.Hash.eqv(A, A) should return true", testCatsHashEqvTrue),
+    property("cats.Hash.eqv(A, A) should return false", testCatsHashEqvFalse),
+  )
+
+  def testMyHashHash: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyNum(n)).log("myNum")
+  } yield {
+    val expected = myNum.##
+    val actual   = MyHash[MyNum].hash(myNum)
+    actual ==== expected
+  }
+
+  def testMyHashEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = MyHash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testMyHashEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = MyHash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsHashHash: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyNum(n)).log("myNum")
+  } yield {
+    val expected = myNum.##
+    val actual   = Hash[MyNum].hash(myNum)
+    actual ==== expected
+  }
+
+  def testCatsHashEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = Hash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testCatsHashEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = Hash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsHashWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsHashWithoutCatsSpec.scala
@@ -1,0 +1,62 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsKernelInstances.{MyHash, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsHashWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("MyHash.hash(A) should return hash", testMyHashHash),
+    property("MyHash.eqv(A, A) should return true", testMyHashEqvTrue),
+    property("MyHash.eqv(A, A) should return false", testMyHashEqvFalse),
+    example("test cats.Hash", testCatsHash),
+  )
+
+  def testMyHashHash: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyNum(n)).log("myNum")
+  } yield {
+    val expected = myNum.##
+    val actual   = MyHash[MyNum].hash(myNum)
+    actual ==== expected
+  }
+
+  def testMyHashEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = MyHash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testMyHashEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = MyHash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsHash: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsHash}
+                      |orphan_instance.OrphanCatsKernelInstances.MyNum.catsHash
+                      |                                                ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsKernelInstances.MyNum.catsHash"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsHashWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsHashWithoutCatsSpec.scala
@@ -1,0 +1,67 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyHash, MyNum}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsHashWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("MyHash.hash(A) should return hash", testMyHashHash),
+    property("MyHash.eqv(A, A) should return true", testMyHashEqvTrue),
+    property("MyHash.eqv(A, A) should return false", testMyHashEqvFalse),
+    example("test cats.Hash", testCatsHash),
+  )
+
+  def testMyHashHash: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyNum(n)).log("myNum")
+  } yield {
+    val expected = myNum.##
+    val actual   = MyHash[MyNum].hash(myNum)
+    actual ==== expected
+  }
+
+  def testMyHashEqvTrue: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n1)).log("myNum2")
+  } yield {
+    val expected = true
+    val actual   = MyHash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  def testMyHashEqvFalse: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).map(n2 => if (n1 == n2) n2 + 1 else n2).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = false
+    val actual   = MyHash[MyNum].eqv(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsHash: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsHash
+
+    val actual = typeCheckErrors(
+      """
+        val _ = orphan_instance.OrphanCatsKernelInstances.MyNum.catsHash
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual error message doesn't start with the expected one.")
+
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -25,4 +25,7 @@ object ExpectedMessages {
   val ExpectedMessageForCatsEq: String =
     """Missing an instance of `CatsEq` which means you're trying to use cats.kernel.Eq, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Eq[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsHash: String =
+    """Missing an instance of `CatsHash` which means you're trying to use cats.kernel.Hash, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Hash[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -9,6 +9,7 @@ trait OrphanCatsKernel {
   final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
   final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
   final protected type CatsEq[F[*]]        = OrphanCatsKernel.CatsEq[F]
+  final protected type CatsHash[F[*]]      = OrphanCatsKernel.CatsHash[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -48,6 +49,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsEq {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsEq: CatsEq[cats.kernel.Eq] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsHash` which means you're trying to use cats.kernel.Hash, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Hash[A] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsHash[F[*]]
+  private[OrphanCatsKernel] object CatsHash {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsHash: CatsHash[cats.kernel.Hash] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -9,6 +9,7 @@ trait OrphanCatsKernel {
   final protected type CatsSemigroup[F[*]] = OrphanCatsKernel.CatsSemigroup[F]
   final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
   final protected type CatsEq[F[*]]        = OrphanCatsKernel.CatsEq[F]
+  final protected type CatsHash[F[*]]      = OrphanCatsKernel.CatsHash[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -48,6 +49,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsEq {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsEq: CatsEq[cats.kernel.Eq] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsHash` which means you're trying to use cats.kernel.Hash, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Hash[A] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsHash[F[*]]
+  private[OrphanCatsKernel] object CatsHash {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsHash: CatsHash[cats.kernel.Hash] =
       null // scalafix:ok DisableSyntax.null
   }
 


### PR DESCRIPTION
Close #25: [`orphan-cats`] Add `CatsHash` for `cats.kernel.Hash`

- Add `CatsHash` type alias and `trait` to OrphanCatsKernel for both Scala 2 and 3.
- Include `@implicitNotFound` annotation with helpful error message for missing cats-core dependency.
- Add `MyHash` `trait` and `instance`s in test code.
- Add `catsHash` instances (`implicit`/`given`) for testing.