### PR TITLE
Close #26: [`orphan-cats`] Add `CatsOrder` for `cats.kernel.Order`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsOrderWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsOrderWithCatsSpec.scala
@@ -1,0 +1,40 @@
+package orphan_test
+
+import cats.kernel.Order
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyNum, MyOrder}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsOrderWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyOrder.compare(A, A)", testMyOrderCompare),
+    property("test cats.Order.compare(A, A)", testCatsOrderCompare),
+  )
+
+  def testMyOrderCompare: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = n1.compare(n2)
+    val actual   = MyOrder[MyNum].compare(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsOrderCompare: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = n1.compare(n2)
+    val actual   = Order[MyNum].compare(myNum1, myNum2)
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsOrderWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsOrderWithoutCatsSpec.scala
@@ -1,0 +1,40 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsKernelInstances.{MyNum, MyOrder}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsOrderWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyOrder.compare(A, A)", testMyOrderCompare),
+    example("test cats.Order", testCatsOrder),
+  )
+
+  def testMyOrderCompare: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = n1.compare(n2)
+    val actual   = MyOrder[MyNum].compare(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsOrder: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsOrder}
+                      |orphan_instance.OrphanCatsKernelInstances.MyNum.catsOrder
+                      |                                                ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsKernelInstances.MyNum.catsOrder"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsOrderWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsOrderWithoutCatsSpec.scala
@@ -1,0 +1,45 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsKernelInstances.{MyNum, MyOrder}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsOrderWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyOrder.compare(A, A)", testMyOrderCompare),
+    example("test cats.Order", testCatsOrder),
+  )
+
+  def testMyOrderCompare: Property = for {
+    n1     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n1")
+    n2     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n2")
+    myNum1 <- Gen.constant(MyNum(n1)).log("myNum1")
+    myNum2 <- Gen.constant(MyNum(n2)).log("myNum2")
+  } yield {
+    val expected = n1.compare(n2)
+    val actual   = MyOrder[MyNum].compare(myNum1, myNum2)
+    actual ==== expected
+  }
+
+  def testCatsOrder: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsOrder
+
+    val actual = typeCheckErrors(
+      """
+        val _ = orphan_instance.OrphanCatsKernelInstances.MyNum.catsOrder
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual error message doesn't start with the expected one.")
+
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -28,4 +28,7 @@ object ExpectedMessages {
   val ExpectedMessageForCatsHash: String =
     """Missing an instance of `CatsHash` which means you're trying to use cats.kernel.Hash, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Hash[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsOrder: String =
+    """Missing an instance of `CatsOrder` which means you're trying to use cats.kernel.Order, but cats library is missing in your project config. If you want to have an instance of cats.kernel.Order[A] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -10,6 +10,7 @@ trait OrphanCatsKernel {
   final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
   final protected type CatsEq[F[*]]        = OrphanCatsKernel.CatsEq[F]
   final protected type CatsHash[F[*]]      = OrphanCatsKernel.CatsHash[F]
+  final protected type CatsOrder[F[*]]     = OrphanCatsKernel.CatsOrder[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -62,6 +63,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsHash {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsHash: CatsHash[cats.kernel.Hash] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsOrder` which means you're trying to use cats.kernel.Order, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Order[A] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsOrder[F[*]]
+  private[OrphanCatsKernel] object CatsOrder {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsOrder: CatsOrder[cats.kernel.Order] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -10,6 +10,7 @@ trait OrphanCatsKernel {
   final protected type CatsMonoid[F[*]]    = OrphanCatsKernel.CatsMonoid[F]
   final protected type CatsEq[F[*]]        = OrphanCatsKernel.CatsEq[F]
   final protected type CatsHash[F[*]]      = OrphanCatsKernel.CatsHash[F]
+  final protected type CatsOrder[F[*]]     = OrphanCatsKernel.CatsOrder[F]
 }
 private[orphan] object OrphanCatsKernel {
 
@@ -62,6 +63,19 @@ private[orphan] object OrphanCatsKernel {
   private[OrphanCatsKernel] object CatsHash {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsHash: CatsHash[cats.kernel.Hash] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsOrder` which means you're trying to use cats.kernel.Order, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.kernel.Order[A] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsOrder[F[*]]
+  private[OrphanCatsKernel] object CatsOrder {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsOrder: CatsOrder[cats.kernel.Order] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
@@ -38,6 +38,13 @@ object OrphanCatsKernelInstances {
     def apply[A: MyHash]: MyHash[A] = implicitly[MyHash[A]]
   }
 
+  trait MyOrder[A] {
+    def compare(x: A, y: A): Int
+  }
+  object MyOrder {
+    def apply[A: MyOrder]: MyOrder[A] = implicitly[MyOrder[A]]
+  }
+
   final case class MyNum(n: Int)
   object MyNum extends MyCatsKernelInstances {
     implicit def myNumMySemigroup: MySemigroup[MyNum] = new MySemigroup[MyNum] {
@@ -61,6 +68,10 @@ object OrphanCatsKernelInstances {
 
       @SuppressWarnings(Array("org.wartremover.warts.Equals"))
       override def eqv(x: MyNum, y: MyNum): Boolean = x == y
+    }
+
+    implicit def myNumMyOrder: MyOrder[MyNum] = new MyOrder[MyNum] {
+      override def compare(x: MyNum, y: MyNum): Int = x.n.compare(y.n)
     }
 
   }
@@ -97,7 +108,7 @@ object OrphanCatsKernelInstances {
     }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
-  private[orphan_instance] trait MyCatsKernelInstances3 extends OrphanCatsKernel {
+  private[orphan_instance] trait MyCatsKernelInstances3 extends MyCatsKernelInstances4 {
     @nowarn213(
       """msg=evidence parameter .+ of type (.+\.)*CatsHash\[F\] in method catsHash is never used"""
     )
@@ -106,6 +117,16 @@ object OrphanCatsKernelInstances {
       override def hash(x: MyNum): Int = x.##
 
       override def eqv(x: MyNum, y: MyNum): Boolean = cats.kernel.Eq[Int].eqv(x.n, y.n)
+    }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsKernelInstances4 extends OrphanCatsKernel {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CatsOrder\[F\] in method catsOrder is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsOrder[F[*]: CatsOrder]: F[MyNum] = new cats.kernel.Order[MyNum] {
+      override def compare(x: MyNum, y: MyNum): Int = x.n.compare(y.n)
     }.asInstanceOf[F[MyNum]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 


### PR DESCRIPTION
Close #26: [`orphan-cats`] Add `CatsOrder` for `cats.kernel.Order`

- Add `CatsOrder` type alias to `OrphanCatsKernel`
- Implement `CatsOrder` `trait` with `@implicitNotFound` annotation with helpful error messages for missing cats-core dependency.
- Add `MyOrder` `trait` and instances to test for both Scala 2 and 3
- Add `MyOrder` `trait` and `instance`s in test code.
- Add `catsOrder` instances (`implicit`/`given`) for testing.