### PR TITLE
Close #24: [`orphan-cats`] Add `CatsShow` for `cats.Show`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsShowWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsShowWithCatsSpec.scala
@@ -1,0 +1,49 @@
+package orphan_test
+
+import cats.Show
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{Another, MyBox, MyShow, Something}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsShowWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyShow.show(A)", testMyShowShow),
+    property("test cats.Show.show(A)", testCatsShowShow),
+    property("test cats.Show.show(A) 2", testCatsShowShow2),
+  )
+
+  implicit def intMyShow: MyShow[Int] = _.toString
+
+  def testMyShowShow: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyBox(n)).log("myNum")
+  } yield {
+    val expected = s"MyBox(a=${n.toString})"
+    val actual   = MyShow[MyBox[Int]].show(myNum)
+    actual ==== expected
+  }
+
+  def testCatsShowShow: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyBox(n)).log("myNum")
+  } yield {
+    val expected = s"MyBox(a=${n.toString})"
+    val actual   = Show[MyBox[Int]].show(myNum)
+    actual ==== expected
+  }
+
+  def testCatsShowShow2: Property = for {
+    n         <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    something <- Gen.constant(Something(Another(n))).log("something")
+  } yield {
+    val expected = s"Something(a=Another(n=${n.toString}))"
+    val actual   = Show[Something[Another]].show(something)
+
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsShowWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsShowWithoutCatsSpec.scala
@@ -1,0 +1,40 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan.testing.CompileTimeError
+import orphan_instance.OrphanCatsInstances.{MyBox, MyShow}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsShowWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyShow.show(A)", testMyShowShow),
+    example("test cats.Show", testCatsShow),
+  )
+
+  implicit def intMyShow: MyShow[Int] = _.toString
+
+  def testMyShowShow: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyBox(n)).log("myNum")
+  } yield {
+    val expected = s"MyBox(a=${n.toString})"
+    val actual   = MyShow[MyBox[Int]].show(myNum)
+    actual ==== expected
+  }
+
+  def testCatsShow: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsShow}
+                      |orphan_instance.OrphanCatsInstances.MyBox.catsShow
+                      |                                          ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsInstances.MyBox.catsShow"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsShowWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsShowWithoutCatsSpec.scala
@@ -1,0 +1,45 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyShow}
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CatsShowWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyShow.show(A)", testMyShowShow),
+    example("test cats.Show", testCatsShow),
+  )
+
+  given intMyShow: MyShow[Int] = _.toString
+
+  def testMyShowShow: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myNum <- Gen.constant(MyBox(n)).log("myNum")
+  } yield {
+    val expected = s"MyBox(a=${n.toString})"
+    val actual   = MyShow[MyBox[Int]].show(myNum)
+    actual ==== expected
+  }
+
+  def testCatsShow: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = orphan_test.ExpectedMessages.ExpectedMessageForCatsShow
+
+    val actual = typeCheckErrors(
+      """
+        val _ = orphan_instance.OrphanCatsInstances.MyBox.catsShow
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual error message doesn't start with the expected one.")
+
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -4,6 +4,10 @@ package orphan_test
   * @since 2025-07-28
   */
 object ExpectedMessages {
+
+  val ExpectedMessageForCatsShow: String =
+    """Missing an instance of `CatsShow` which means you're trying to use cats.Show, but cats library is missing in your project config. If you want to have an instance of cats.Show[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
   val ExpectedMessageForCatsFunctor: String =
     """Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -6,12 +6,28 @@ import scala.annotation.implicitNotFound
   * @since 2025-07-28
   */
 trait OrphanCats {
+  final protected type CatsShow[F[*]] = OrphanCats.CatsShow[F]
+
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
   final protected type CatsMonad[F[*[*]]]       = OrphanCats.CatsMonad[F]
   final protected type CatsTraverse[F[*[*]]]    = OrphanCats.CatsTraverse[F]
 }
 private[orphan] object OrphanCats {
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsShow` which means you're trying to use cats.Show, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Show[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsShow[F[*]]
+  private[OrphanCats] object CatsShow {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsShow: CatsShow[cats.Show] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
   @implicitNotFound(
     msg = "Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, " +
       "but cats library is missing in your project config. " +

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -6,12 +6,28 @@ import scala.annotation.implicitNotFound
   * @since 2025-07-28
   */
 trait OrphanCats {
+  final protected type CatsShow[F[*]] = OrphanCats.CatsShow[F]
+
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
   final protected type CatsMonad[F[*[*]]]       = OrphanCats.CatsMonad[F]
   final protected type CatsTraverse[F[*[*]]]    = OrphanCats.CatsTraverse[F]
 }
 private[orphan] object OrphanCats {
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsShow` which means you're trying to use cats.Show, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Show[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsShow[F[*]]
+  private[OrphanCats] object CatsShow {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsShow: CatsShow[cats.Show] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
   @implicitNotFound(
     msg = "Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, " +
       "but cats library is missing in your project config. " +

--- a/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-3/orphan_instance/OrphanCatsInstances.scala
@@ -9,6 +9,14 @@ import scala.annotation.tailrec
   * @since 2025-07-28
   */
 object OrphanCatsInstances {
+
+  trait MyShow[A] {
+    def show(t: A): String
+  }
+  object MyShow {
+    def apply[A: MyShow]: MyShow[A] = summon[MyShow[A]]
+  }
+
   trait MyFunctor[F[*]] {
     def map[A, B](fa: F[A])(f: A => B): F[B]
   }
@@ -48,8 +56,46 @@ object OrphanCatsInstances {
     def apply[F[*]: MyTraverse]: MyTraverse[F] = summon[MyTraverse[F]]
   }
 
+  /////
+
+  final case class Another(n: Int)
+  object Another extends OrphanCats {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[F\] in method catsShow is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given catsShow[F[*]: CatsShow]: F[Another] = new cats.Show[Another] {
+      override def show(t: Another): String = s"Another(n=${t.n.toString})"
+    }.asInstanceOf[F[Another]] // scalafix:ok DisableSyntax.asInstanceOf
+
+  }
+
+  final case class Something[A](a: A)
+  object Something extends OrphanCats {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[F\] in method catsShow is never used"""
+    )
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[G\] in method catsShow is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.ToString"))
+    given catsShow[F[*]: CatsShow, A, G[*]: CatsShow](using g: G[A]): F[Something[A]] = {
+      given showA: cats.Show[A] = g.asInstanceOf[cats.Show[A]] // scalafix:ok DisableSyntax.asInstanceOf
+      new cats.Show[Something[A]] {
+        override def show(t: Something[A]): String = s"Something(a=${showA.show(t.a)})"
+      }.asInstanceOf[F[Something[A]]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+
+  }
+
+  /////
+
   final case class MyBox[A](a: A)
   object MyBox extends CatsInstances {
+
+    given myBoxMyShow[A: MyShow]: MyShow[MyBox[A]] with {
+      override def show(t: MyBox[A]): String = s"MyBox(a=${MyShow[A].show(t.a)})"
+    }
 
     given myBoxMyFunctor: MyFunctor[MyBox] with {
       override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
@@ -125,7 +171,7 @@ object OrphanCatsInstances {
     }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
-  private[orphan_instance] trait MyCatsInstances3 extends OrphanCats {
+  private[orphan_instance] trait MyCatsInstances3 extends MyCatsInstances4 {
     @nowarn(
       """msg=evidence parameter .+ of type (.+\.)*CatsTraverse\[F\] in method catsTraverse is never used"""
     )
@@ -139,6 +185,22 @@ object OrphanCatsInstances {
       override def foldRight[A, B](fa: MyBox[A], lb: cats.Eval[B])(f: (A, cats.Eval[B]) => cats.Eval[B]): cats.Eval[B] =
         f(fa.a, lb)
     }.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[orphan_instance] trait MyCatsInstances4 extends OrphanCats {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[F\] in method catsShow is never used"""
+    )
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[G\] in method catsShow is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given catsShow[F[*]: CatsShow, A, G[*]: CatsShow](using g: G[A]): F[MyBox[A]] = {
+      given showA: cats.Show[A] = g.asInstanceOf[cats.Show[A]] // scalafix:ok DisableSyntax.asInstanceOf
+      new cats.Show[MyBox[A]] {
+        override def show(t: MyBox[A]): String = s"MyBox(a=${showA.show(t.a)})"
+      }.asInstanceOf[F[MyBox[A]]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
   }
 
 }


### PR DESCRIPTION
Close #24: [`orphan-cats`] Add `CatsShow` for `cats.Show`

- Add `CatsShow` type alias to `OrphanCats`
- Implement `CatsShow` `trait` with `@implicitNotFound` annotation with helpful error messages for missing cats-core dependency.
- Add `MyShow` trait and companion object for both Scala 2 and 3 for testing
- Implement `Show` instances for `MyBox` using `MyShow` typeclass for testing
- Add `Another` and `Something` `case class`es with `Cats` `Show` instances for testing