### PR TITLE
orphan v0.1.0

### DIFF
--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,114 @@
+## [0.1.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am1) - 2025-08-04
+
+### New Features
+
+* Add `orphan-cats` module (#1)
+***
+* [`orphan-cats`] Add `OrphanCats` and add `CatsFunctor` for `cats.Functor` (#3)
+
+  - [x] `OrphanCats` containing
+    - [x] `CatsFunctor`
+  - [x] For testing, `OrphanCatsInstances`
+    - [x] a `cats.Functor` instance for testing
+  - [x] Add a test module with cats
+    - [x] Add a test for `CatsFunctor`
+  - [x] Add a test module without cats
+    - [x] Add a test for `CatsFunctor`
+
+***
+* [`orphan-cats`] Add `CatsApplicative` for `cats.Applicative` (#10)
+  - [x] Add `CatsApplicative` to `OrphanCats`
+  
+  For testing, `OrphanCatsInstances`
+  - [x] Add `MyApplicative` instance for testing
+  - [x] Add `cats.Applicative` instance for testing
+  - [x] Add a test for `CatsApplicative` in the test module with cats
+  - [x] Add a test for `CatsApplicative` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsMonad` for `cats.Monad` (#12)
+  - [x] Add `CatsMonad` to `OrphanCats`
+
+  For testing, `OrphanCatsInstances`
+  - [x] Add `MyMonad` instance for testing
+  - [x] Add `cats.Monad` instance for testing
+  - [x] Add tests for `CatsMonad` in the test module with cats
+  - [x] Add tests for `CatsMonad` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsSemigroup` for `cats.kernel.Semigroup` (#14)
+  - [x] Add `OrphanCatsKernel`
+  - [x] Add `CatsSemigroup` to `OrphanCatsKernel`
+
+  For testing, `OrphanCatsKernelInstances`
+  - [x] Add `MySemigroup` instance for testing
+  - [x] Add `cats.kernel.Semigroup` instance for testing
+  - [x] Add tests for `CatsSemigroup` in the test module with cats
+  - [x] Add tests for `CatsSemigroup` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsMonoid` for `cats.kernel.Monoid` (#15)
+  - [x] Add `CatsMonoid` to `OrphanCatsKernel`
+
+  For testing, `OrphanCatsKernelInstances`
+  - [x] Add `MyMonoid` instance for testing
+  - [x] Add `cats.kernel.Monoid` instance for testing
+  - [x] Add tests for `CatsMonoid` in the test module with cats
+  - [x] Add tests for `CatsMonoid` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsTraverse` for `cats.Traverse` (#20)
+  - [x] Add `CatsTraverse` to `OrphanCats`
+
+  For testing, `OrphanCatsInstances`
+  - [x] Add `MyTraverse` instance for testing
+  - [x] Add `cats.Traverse` instance for testing
+  - [x] Add tests for `CatsTraverse` in the test module with cats
+  - [x] Add tests for `CatsTraverse` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsEq` for `cats.kernel.Eq` (#23)
+  - [x] Add `CatsEq` to `OrphanCatsKernel`
+
+  For testing, `OrphanCatsKernelInstances`
+  - [x] Add `MyEq` instance for testing
+  - [x] Add `cats.kernel.Eq` instance for testing
+  - [x] Add tests for `CatsEq` in the test module with cats
+  - [x] Add tests for `CatsEq` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsShow` for `cats.Show` (#24)
+  - [x] Add `CatsShow` to `OrphanCats`
+
+  For testing, `OrphanCatsInstances`
+  - [x] Add `MyShow` instance for testing
+  - [x] Add `cats.Show` instance for testing
+  - [x] Add tests for `CatsShow` in the test module with cats
+  - [x] Add tests for `CatsShow` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsHash` for `cats.kernel.Hash` (#25)
+  - [X] Add `CatsHash` to `OrphanCatsKernel`
+
+  For testing, `OrphanCatsKernelInstances`
+  - [X] Add `MyHash` instance for testing
+  - [X] Add `cats.kernel.Hash` instance for testing
+  - [X] Add tests for `CatsHash` in the test module with cats
+  - [X] Add tests for `CatsHash` in the test module without cats
+***
+* [`orphan-cats`] Add `CatsOrder` for `cats.kernel.Order` (#26)
+  - [x] Add `CatsOrder` to `OrphanCatsKernel`
+
+  For testing, `OrphanCatsKernelInstances`
+  - [x] Add `MyOrder` instance for testing
+  - [x] Add `cats.kernel.Order` instance for testing
+  - [x] Add tests for `CatsOrder` in the test module with cats
+  - [x] Add tests for `CatsOrder` in the test module without cats
+
+### Bug Fixed
+
+* Fix `@implicitNotFound` error message (#8)
+
+  The current message
+  ```
+  Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided by extras, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt
+  ```
+  should be
+  ```
+  Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt
+  ```
+  so `provided by extras` should be `provided`.
+


### PR DESCRIPTION
# orphan v0.1.0
## [0.1.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am1) - 2025-08-04

### New Features

* Add `orphan-cats` module (#1)
***
* [`orphan-cats`] Add `OrphanCats` and add `CatsFunctor` for `cats.Functor` (#3)

  - [x] `OrphanCats` containing
    - [x] `CatsFunctor`
  - [x] For testing, `OrphanCatsInstances`
    - [x] a `cats.Functor` instance for testing
  - [x] Add a test module with cats
    - [x] Add a test for `CatsFunctor`
  - [x] Add a test module without cats
    - [x] Add a test for `CatsFunctor`

***
* [`orphan-cats`] Add `CatsApplicative` for `cats.Applicative` (#10)
  - [x] Add `CatsApplicative` to `OrphanCats`
  
  For testing, `OrphanCatsInstances`
  - [x] Add `MyApplicative` instance for testing
  - [x] Add `cats.Applicative` instance for testing
  - [x] Add a test for `CatsApplicative` in the test module with cats
  - [x] Add a test for `CatsApplicative` in the test module without cats
***
* [`orphan-cats`] Add `CatsMonad` for `cats.Monad` (#12)
  - [x] Add `CatsMonad` to `OrphanCats`

  For testing, `OrphanCatsInstances`
  - [x] Add `MyMonad` instance for testing
  - [x] Add `cats.Monad` instance for testing
  - [x] Add tests for `CatsMonad` in the test module with cats
  - [x] Add tests for `CatsMonad` in the test module without cats
***
* [`orphan-cats`] Add `CatsSemigroup` for `cats.kernel.Semigroup` (#14)
  - [x] Add `OrphanCatsKernel`
  - [x] Add `CatsSemigroup` to `OrphanCatsKernel`

  For testing, `OrphanCatsKernelInstances`
  - [x] Add `MySemigroup` instance for testing
  - [x] Add `cats.kernel.Semigroup` instance for testing
  - [x] Add tests for `CatsSemigroup` in the test module with cats
  - [x] Add tests for `CatsSemigroup` in the test module without cats
***
* [`orphan-cats`] Add `CatsMonoid` for `cats.kernel.Monoid` (#15)
  - [x] Add `CatsMonoid` to `OrphanCatsKernel`

  For testing, `OrphanCatsKernelInstances`
  - [x] Add `MyMonoid` instance for testing
  - [x] Add `cats.kernel.Monoid` instance for testing
  - [x] Add tests for `CatsMonoid` in the test module with cats
  - [x] Add tests for `CatsMonoid` in the test module without cats
***
* [`orphan-cats`] Add `CatsTraverse` for `cats.Traverse` (#20)
  - [x] Add `CatsTraverse` to `OrphanCats`

  For testing, `OrphanCatsInstances`
  - [x] Add `MyTraverse` instance for testing
  - [x] Add `cats.Traverse` instance for testing
  - [x] Add tests for `CatsTraverse` in the test module with cats
  - [x] Add tests for `CatsTraverse` in the test module without cats
***
* [`orphan-cats`] Add `CatsEq` for `cats.kernel.Eq` (#23)
  - [x] Add `CatsEq` to `OrphanCatsKernel`

  For testing, `OrphanCatsKernelInstances`
  - [x] Add `MyEq` instance for testing
  - [x] Add `cats.kernel.Eq` instance for testing
  - [x] Add tests for `CatsEq` in the test module with cats
  - [x] Add tests for `CatsEq` in the test module without cats
***
* [`orphan-cats`] Add `CatsShow` for `cats.Show` (#24)
  - [x] Add `CatsShow` to `OrphanCats`

  For testing, `OrphanCatsInstances`
  - [x] Add `MyShow` instance for testing
  - [x] Add `cats.Show` instance for testing
  - [x] Add tests for `CatsShow` in the test module with cats
  - [x] Add tests for `CatsShow` in the test module without cats
***
* [`orphan-cats`] Add `CatsHash` for `cats.kernel.Hash` (#25)
  - [X] Add `CatsHash` to `OrphanCatsKernel`

  For testing, `OrphanCatsKernelInstances`
  - [X] Add `MyHash` instance for testing
  - [X] Add `cats.kernel.Hash` instance for testing
  - [X] Add tests for `CatsHash` in the test module with cats
  - [X] Add tests for `CatsHash` in the test module without cats
***
* [`orphan-cats`] Add `CatsOrder` for `cats.kernel.Order` (#26)
  - [x] Add `CatsOrder` to `OrphanCatsKernel`

  For testing, `OrphanCatsKernelInstances`
  - [x] Add `MyOrder` instance for testing
  - [x] Add `cats.kernel.Order` instance for testing
  - [x] Add tests for `CatsOrder` in the test module with cats
  - [x] Add tests for `CatsOrder` in the test module without cats

### Bug Fixed

* Fix `@implicitNotFound` error message (#8)

  The current message
  ```
  Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided by extras, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt
  ```
  should be
  ```
  Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt
  ```
  so `provided by extras` should be `provided`.

