### PR TITLE
Close #41: [`orphan-circe`] Add `OrphanCirce` with `CirceEncoder` for circe support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,14 @@ lazy val orphan = (project in file("."))
     orphanCatsTestWithoutCatsJs,
     orphanCatsTestWithCatsJvm,
     orphanCatsTestWithCatsJs,
+    orphanCirceJvm,
+    orphanCirceJs,
+    orphanCirceTestJvm,
+    orphanCirceTestJs,
+    orphanCirceTestWithoutCirceJvm,
+    orphanCirceTestWithoutCirceJs,
+    orphanCirceTestWithCirceJvm,
+    orphanCirceTestWithCirceJs,
   )
 
 lazy val orphanCats    = module("cats", crossProject(JVMPlatform, JSPlatform))
@@ -78,6 +86,55 @@ lazy val orphanCatsTestWithCats    = module("cats-test-with-cats", crossProject(
   .dependsOn(orphanCats % props.IncludeTest)
 lazy val orphanCatsTestWithCatsJvm = orphanCatsTestWithCats.jvm
 lazy val orphanCatsTestWithCatsJs  = orphanCatsTestWithCats.js.settings(jsCommonSettings)
+
+lazy val orphanCirce    = module("circe", crossProject(JVMPlatform, JSPlatform))
+  .settings(
+    libraryDependencies ++= List(
+      libs.circeCore.value % Optional,
+    ) ++ (
+      if (isScala3(scalaVersion.value)) List.empty
+      else
+        List(
+          libs.scalacCompatAnnotation,
+          libs.tests.scalaReflect.value
+        )
+    ),
+  )
+lazy val orphanCirceJvm = orphanCirce.jvm
+lazy val orphanCirceJs  = orphanCirce.js.settings(jsCommonSettings)
+
+lazy val orphanCirceTest    = module("circe-test", crossProject(JVMPlatform, JSPlatform))
+  .settings(noPublish)
+  .settings(
+    libraryDependencies ++= List(libs.circeGeneric.value % Optional),
+  )
+  .dependsOn(orphanCirce % props.IncludeTest)
+lazy val orphanCirceTestJvm = orphanCirceTest.jvm
+lazy val orphanCirceTestJs  = orphanCirceTest.js.settings(jsCommonSettings)
+
+lazy val orphanCirceTestWithoutCirce    = module("circe-test-without-circe", crossProject(JVMPlatform, JSPlatform))
+  .settings(noPublish)
+  .settings(
+    libraryDependencies ++= List(libs.tests.extrasTestingTools.value),
+    Test / libraryDependencies ~= (libs => libs.filterNot(_.name.startsWith("circe")))
+  )
+  .dependsOn(orphanCirceTest % props.IncludeTest)
+lazy val orphanCirceTestWithoutCirceJvm = orphanCirceTestWithoutCirce.jvm
+lazy val orphanCirceTestWithoutCirceJs  = orphanCirceTestWithoutCirce.js.settings(jsCommonSettings)
+
+lazy val orphanCirceTestWithCirce    = module("circe-test-with-circe", crossProject(JVMPlatform, JSPlatform))
+  .settings(noPublish)
+  .settings(
+    libraryDependencies ++= List(
+      libs.circeCore.value    % Test,
+      libs.circeGeneric.value % Test,
+      libs.circeJawn.value    % Test,
+      libs.circeLiteral.value % Test,
+    ),
+  )
+  .dependsOn(orphanCirceTest % props.IncludeTest)
+lazy val orphanCirceTestWithCirceJvm = orphanCirceTestWithCirce.jvm
+lazy val orphanCirceTestWithCirceJs  = orphanCirceTestWithCirce.js.settings(jsCommonSettings)
 
 lazy val props =
   new {
@@ -117,6 +174,8 @@ lazy val props =
 
     val ScalacCompatAnnotationVersion = "0.1.4"
 
+    val CirceVersion = "0.14.2"
+
   }
 
 lazy val libs = new {
@@ -125,6 +184,11 @@ lazy val libs = new {
     Def.setting("org.typelevel" %%% "cats-core" % props.CatsVersion)
 
   lazy val scalacCompatAnnotation = "org.typelevel" %% "scalac-compat-annotation" % props.ScalacCompatAnnotationVersion
+
+  lazy val circeCore    = Def.setting("io.circe" %%% "circe-core" % props.CirceVersion)
+  lazy val circeGeneric = Def.setting("io.circe" %%% "circe-generic" % props.CirceVersion)
+  lazy val circeLiteral = Def.setting("io.circe" %%% "circe-literal" % props.CirceVersion)
+  lazy val circeJawn    = Def.setting("io.circe" %%% "circe-jawn" % props.CirceVersion)
 
   lazy val tests = new {
 

--- a/modules/orphan-circe-test-with-circe/shared/src/test/scala/orphan_test/CirceEncoderWithCirceSpec.scala
+++ b/modules/orphan-circe-test-with-circe/shared/src/test/scala/orphan_test/CirceEncoderWithCirceSpec.scala
@@ -1,0 +1,35 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import io.circe.literal.*
+import io.circe.syntax.*
+import orphan_instance.OrphanCirceInstances.MyBox
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceEncoderWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("testCirceEncoder", testCirceEncoder)
+  )
+
+  def testCirceEncoder: Property = for {
+    id       <- Gen.int(Range.linear(0, Int.MaxValue)).log("id")
+    name     <- Gen.string(Gen.alpha, Range.linear(0, 10)).log("name")
+    isActive <- Gen.boolean.log("isActive")
+    myBox    <- Gen.constant(MyBox(id, name, isActive)).log("myBox")
+  } yield {
+    val expected =
+      json"""{
+               "id":$id,
+               "name":$name,
+               "isActive":$isActive
+             }"""
+
+    val actual = myBox.asJson
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceEncoderWithCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceEncoderWithCirceSpec.scala
@@ -1,0 +1,27 @@
+package orphan_test
+
+import extras.testing.CompileTimeError
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceEncoderWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("testCirceEncoder", testCirceEncoder)
+  )
+
+  def testCirceEncoder: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCirceEncoder}
+                      |orphan_instance.OrphanCirceInstances.MyBox.circeEncoder
+                      |                                           ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCirceInstances.MyBox.circeEncoder"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceEncoderWithCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceEncoderWithCirceSpec.scala
@@ -1,0 +1,30 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceEncoderWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("testCirceEncoder", testCirceEncoder)
+  )
+
+  def testCirceEncoder: Result = {
+
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = ExpectedMessages.ExpectedMessageForCirceEncoder
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCirceInstances.MyBox.circeEncoder
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -1,0 +1,11 @@
+package orphan_test
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object ExpectedMessages {
+
+  val ExpectedMessageForCirceEncoder: String =
+    """Missing an instance of `CirceEncoder` which means you're trying to use io.circe.Encoder, but circe library is missing in your project config. If you want to have an instance of io.circe.Encoder[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+
+}

--- a/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
@@ -1,0 +1,25 @@
+package orphan_instance
+
+import org.typelevel.scalaccompat.annotation.nowarn213
+import orphan.OrphanCirce
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object OrphanCirceInstances {
+
+  final case class MyBox(id: Int, name: String, isActive: Boolean)
+  object MyBox extends MyCirceInstances
+
+  private[orphan_instance] trait MyCirceInstances extends OrphanCirce {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def circeEncoder[F[*]: CirceEncoder]: F[MyBox] = {
+      val myBoxEncoder: io.circe.Encoder[MyBox] = io.circe.generic.semiauto.deriveEncoder[MyBox]
+      myBoxEncoder.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+  }
+
+}

--- a/modules/orphan-circe-test/shared/src/main/scala-3/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-3/orphan_instance/OrphanCirceInstances.scala
@@ -1,0 +1,24 @@
+package orphan_instance
+
+import scala.annotation.nowarn
+import orphan.OrphanCirce
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object OrphanCirceInstances {
+
+  final case class MyBox(id: Int, name: String, isActive: Boolean)
+  object MyBox extends MyCirceInstances
+
+  private[orphan_instance] trait MyCirceInstances extends OrphanCirce {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given circeEncoder[F[*]: CirceEncoder]: F[MyBox] = {
+      io.circe.generic.semiauto.deriveEncoder[MyBox].asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+  }
+
+}

--- a/modules/orphan-circe/shared/src/main/scala-2/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-2/orphan/OrphanCirce.scala
@@ -1,0 +1,24 @@
+package orphan
+
+import scala.annotation.implicitNotFound
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+trait OrphanCirce {
+  final protected type CirceEncoder[F[*]] = OrphanCirce.CirceEncoder[F]
+}
+private[orphan] object OrphanCirce {
+  @implicitNotFound(
+    msg = "Missing an instance of `CirceEncoder` which means you're trying to use io.circe.Encoder, " +
+      "but circe library is missing in your project config. " +
+      "If you want to have an instance of io.circe.Encoder[A] provided, " +
+      """please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CirceEncoder[F[*]]
+  private[OrphanCirce] object CirceEncoder {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCirceEncoder: CirceEncoder[io.circe.Encoder] =
+      null // scalafix:ok DisableSyntax.null
+  }
+}

--- a/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
@@ -1,0 +1,24 @@
+package orphan
+
+import scala.annotation.implicitNotFound
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+trait OrphanCirce {
+  final protected type CirceEncoder[F[*]] = OrphanCirce.CirceEncoder[F]
+}
+private[orphan] object OrphanCirce {
+  @implicitNotFound(
+    msg = "Missing an instance of `CirceEncoder` which means you're trying to use io.circe.Encoder, " +
+      "but circe library is missing in your project config. " +
+      "If you want to have an instance of io.circe.Encoder[A] provided, " +
+      """please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CirceEncoder[F[*]]
+  private[OrphanCirce] object CirceEncoder {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCirceEncoder: CirceEncoder[io.circe.Encoder] =
+      null // scalafix:ok DisableSyntax.null
+  }
+}


### PR DESCRIPTION
## Close #41: [`orphan-circe`] Add `OrphanCirce` with `CirceEncoder` for circe support

Add phantom CirceEncoder gate and tests (Scala 2/3)

Introduce `OrphanCirce` (Scala 2 & 3) with a phantom `CirceEncoder[F[*]]` and `@implicitNotFound` guidance to require circe-core when an `io.circe.Encoder` is used.

- OrphanCirce (Scala 2/3):
  - `orphan.OrphanCirce` defines `CirceEncoder[F[*]]` (phantom).
  - Provides an implicit/given for `io.circe.Encoder` to gate usage.
  - Clear `@implicitNotFound` message instructs adding `"io.circe" %% "circe-core" % CIRCE_VERSION`.

- Instances/examples:
  - `orphan_instance.OrphanCirceInstances` with `MyBox` and a derived `io.circe.Encoder`.
  - Gated by `CirceEncoder[F[*]]` (implicit in Scala 2, given in Scala 3).

- Tests:
  - With circe: `CirceEncoderWithCirceSpec` asserts `MyBox` JSON matches expected.
  - Without circe:
    - Scala 2: checks compile-time error via `extras.testing.CompileTimeError`.
    - Scala 3: checks with `scala.compiletime.testing.typeCheckErrors`.
  - Shared `ExpectedMessages` centralizes the expected error message.
  - Check compile-time error in both Scala 2 and 3.

- Build:
  - Update build.sbt to wire new modules and test dependencies.