### PR TITLE
Close #42: [`orphan-circe`] Add `CirceDecoder` for `circe` to `OrphanCirce`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,7 @@ lazy val orphanCirceTestWithCirce    = module("circe-test-with-circe", crossProj
       libs.circeGeneric.value % Test,
       libs.circeJawn.value    % Test,
       libs.circeLiteral.value % Test,
+      libs.circeParser.value  % Test,
     ),
   )
   .dependsOn(orphanCirceTest % props.IncludeTest)
@@ -188,6 +189,7 @@ lazy val libs = new {
   lazy val circeCore    = Def.setting("io.circe" %%% "circe-core" % props.CirceVersion)
   lazy val circeGeneric = Def.setting("io.circe" %%% "circe-generic" % props.CirceVersion)
   lazy val circeLiteral = Def.setting("io.circe" %%% "circe-literal" % props.CirceVersion)
+  lazy val circeParser  = Def.setting("io.circe" %%% "circe-parser" % props.CirceVersion)
   lazy val circeJawn    = Def.setting("io.circe" %%% "circe-jawn" % props.CirceVersion)
 
   lazy val tests = new {

--- a/modules/orphan-circe-test-with-circe/shared/src/test/scala/orphan_test/CirceDecoderWithCirceSpec.scala
+++ b/modules/orphan-circe-test-with-circe/shared/src/test/scala/orphan_test/CirceDecoderWithCirceSpec.scala
@@ -1,0 +1,39 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import io.circe.literal.*
+import io.circe.parser.*
+import orphan_instance.OrphanCirceInstances.MyBox
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceDecoderWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("testCirceDecoder", testCirceDecoder)
+  )
+
+  def testCirceDecoder: Property = for {
+    id       <- Gen.int(Range.linear(0, Int.MaxValue)).log("id")
+    name     <- Gen.string(Gen.alpha, Range.linear(0, 10)).log("name")
+    isActive <- Gen.boolean.log("isActive")
+    myBox    <- Gen.constant(MyBox(id, name, isActive)).log("myBox")
+  } yield {
+    val json =
+      json"""{
+               "id":$id,
+               "name":$name,
+               "isActive":$isActive
+             }"""
+
+    val expected = myBox
+    decode[MyBox](json.noSpaces).matchPattern {
+      case Right(actual) =>
+        actual ==== expected
+    }
+
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceDecoderWithCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceDecoderWithCirceSpec.scala
@@ -1,0 +1,27 @@
+package orphan_test
+
+import extras.testing.CompileTimeError
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceDecoderWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("testCirceDecoder", testCirceDecoder)
+  )
+
+  def testCirceDecoder: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCirceDecoder}
+                      |orphan_instance.OrphanCirceInstances.MyBox.circeDecoder
+                      |                                           ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCirceInstances.MyBox.circeDecoder"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceDecoderWithCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceDecoderWithCirceSpec.scala
@@ -1,0 +1,30 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceDecoderWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("testCirceDecoder", testCirceDecoder)
+  )
+
+  def testCirceDecoder: Result = {
+
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = ExpectedMessages.ExpectedMessageForCirceDecoder
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCirceInstances.MyBox.circeDecoder
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -8,4 +8,7 @@ object ExpectedMessages {
   val ExpectedMessageForCirceEncoder: String =
     """Missing an instance of `CirceEncoder` which means you're trying to use io.circe.Encoder, but circe library is missing in your project config. If you want to have an instance of io.circe.Encoder[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCirceDecoder: String =
+    """Missing an instance of `CirceDecoder` which means you're trying to use io.circe.Decoder, but circe library is missing in your project config. If you want to have an instance of io.circe.Decoder[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
@@ -11,7 +11,7 @@ object OrphanCirceInstances {
   final case class MyBox(id: Int, name: String, isActive: Boolean)
   object MyBox extends MyCirceInstances
 
-  private[orphan_instance] trait MyCirceInstances extends OrphanCirce {
+  private[orphan_instance] trait MyCirceInstances extends MyCirceInstances1 {
     @nowarn213(
       """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
     )
@@ -19,6 +19,17 @@ object OrphanCirceInstances {
     implicit def circeEncoder[F[*]: CirceEncoder]: F[MyBox] = {
       val myBoxEncoder: io.circe.Encoder[MyBox] = io.circe.generic.semiauto.deriveEncoder[MyBox]
       myBoxEncoder.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+  }
+
+  private[orphan_instance] trait MyCirceInstances1 extends OrphanCirce {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CirceDecoder\[F\] in method circeDecoder is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def circeDecoder[F[*]: CirceDecoder]: F[MyBox] = {
+      val myBoxDecoder: io.circe.Decoder[MyBox] = io.circe.generic.semiauto.deriveDecoder[MyBox]
+      myBoxDecoder.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
     }
   }
 

--- a/modules/orphan-circe-test/shared/src/main/scala-3/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-3/orphan_instance/OrphanCirceInstances.scala
@@ -11,13 +11,23 @@ object OrphanCirceInstances {
   final case class MyBox(id: Int, name: String, isActive: Boolean)
   object MyBox extends MyCirceInstances
 
-  private[orphan_instance] trait MyCirceInstances extends OrphanCirce {
+  private[orphan_instance] trait MyCirceInstances extends MyCirceInstances1 {
     @nowarn(
       """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
     )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     given circeEncoder[F[*]: CirceEncoder]: F[MyBox] = {
       io.circe.generic.semiauto.deriveEncoder[MyBox].asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+  }
+
+  private[orphan_instance] trait MyCirceInstances1 extends OrphanCirce {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CirceDecoder\[F\] in method circeDecoder is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given circeDecoder[F[*]: CirceDecoder]: F[MyBox] = {
+      io.circe.generic.semiauto.deriveDecoder[MyBox].asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
     }
   }
 

--- a/modules/orphan-circe/shared/src/main/scala-2/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-2/orphan/OrphanCirce.scala
@@ -7,6 +7,7 @@ import scala.annotation.implicitNotFound
   */
 trait OrphanCirce {
   final protected type CirceEncoder[F[*]] = OrphanCirce.CirceEncoder[F]
+  final protected type CirceDecoder[F[*]] = OrphanCirce.CirceDecoder[F]
 }
 private[orphan] object OrphanCirce {
   @implicitNotFound(
@@ -21,4 +22,18 @@ private[orphan] object OrphanCirce {
     @inline implicit final def getCirceEncoder: CirceEncoder[io.circe.Encoder] =
       null // scalafix:ok DisableSyntax.null
   }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CirceDecoder` which means you're trying to use io.circe.Decoder, " +
+      "but circe library is missing in your project config. " +
+      "If you want to have an instance of io.circe.Decoder[A] provided, " +
+      """please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CirceDecoder[F[*]]
+  private[OrphanCirce] object CirceDecoder {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCirceDecoder: CirceDecoder[io.circe.Decoder] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
 }

--- a/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
@@ -7,6 +7,7 @@ import scala.annotation.implicitNotFound
   */
 trait OrphanCirce {
   final protected type CirceEncoder[F[*]] = OrphanCirce.CirceEncoder[F]
+  final protected type CirceDecoder[F[*]] = OrphanCirce.CirceDecoder[F]
 }
 private[orphan] object OrphanCirce {
   @implicitNotFound(
@@ -21,4 +22,18 @@ private[orphan] object OrphanCirce {
     final inline given getCirceEncoder: CirceEncoder[io.circe.Encoder] =
       null // scalafix:ok DisableSyntax.null
   }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CirceDecoder` which means you're trying to use io.circe.Decoder, " +
+      "but circe library is missing in your project config. " +
+      "If you want to have an instance of io.circe.Decoder[A] provided, " +
+      """please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CirceDecoder[F[*]]
+  private[OrphanCirce] object CirceDecoder {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCirceDecoder: CirceDecoder[io.circe.Decoder] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
 }


### PR DESCRIPTION
Close #42: [`orphan-circe`] Add `CirceDecoder` for `circe` to `OrphanCirce`

- `core`: Add `CirceDecoder` phantom type with helpful `@implicitNotFound` in `OrphanCirce`
- Instances: provide `circeDecoder` for `MyBox` in `OrphanCirceInstances` for testing