### PR TITLE
Close #43: [`orphan-circe`] Add `CirceCodec` for circe to `OrphanCirce`

### DIFF
--- a/modules/orphan-circe-test-with-circe/shared/src/test/scala/orphan_test/CirceCodecWithCirceSpec.scala
+++ b/modules/orphan-circe-test-with-circe/shared/src/test/scala/orphan_test/CirceCodecWithCirceSpec.scala
@@ -1,0 +1,50 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import io.circe.literal.*
+import io.circe.parser.*
+import io.circe.syntax.*
+import orphan_instance.OrphanCirceInstances.MyBoxForCodec
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceCodecWithCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("testCirceCodec", testCirceCodec)
+  )
+
+  def testCirceCodec: Property = for {
+    id       <- Gen.int(Range.linear(0, Int.MaxValue)).log("id")
+    name     <- Gen.string(Gen.alpha, Range.linear(0, 10)).log("name")
+    isActive <- Gen.boolean.log("isActive")
+    myBox    <- Gen.constant(MyBoxForCodec(id, name, isActive)).log("myBox")
+  } yield {
+    val expectedJson =
+      json"""{
+               "id":$id,
+               "name":$name,
+               "isActive":$isActive
+             }"""
+
+    val actualJson     = myBox.asJson
+    val encodingResult = actualJson ==== expectedJson
+
+    val expected       = myBox
+    val decodingResult = decode[MyBoxForCodec](actualJson.noSpaces).matchPattern {
+      case Right(actual) =>
+        actual ==== expected
+    }
+
+    Result.all(
+      List(
+        encodingResult,
+        decodingResult,
+      )
+    )
+
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceCodecWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceCodecWithoutCirceSpec.scala
@@ -1,0 +1,27 @@
+package orphan_test
+
+import extras.testing.CompileTimeError
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceCodecWithoutCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("testCirceCodec", testCirceCodec)
+  )
+
+  def testCirceCodec: Result = {
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCirceCodec}
+                      |orphan_instance.OrphanCirceInstances.MyBoxForCodec.circeCodec
+                      |                                                   ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCirceInstances.MyBoxForCodec.circeCodec"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceCodecWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceCodecWithoutCirceSpec.scala
@@ -1,0 +1,32 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2025-08-10
+  */
+object CirceCodecWithoutCirceSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("testCirceCodec", testCirceCodec)
+  )
+
+  def testCirceCodec: Result = {
+
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = ExpectedMessages.ExpectedMessageForCirceCodec
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCirceInstances.MyBoxForCodec.circeCodec
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    Result
+      .assert(actualErrorMessage.startsWith(expectedMessage))
+      .log("The actual compile-time error doesn't start with the expected error message.")
+  }
+
+}

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -11,4 +11,7 @@ object ExpectedMessages {
   val ExpectedMessageForCirceDecoder: String =
     """Missing an instance of `CirceDecoder` which means you're trying to use io.circe.Decoder, but circe library is missing in your project config. If you want to have an instance of io.circe.Decoder[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCirceCodec: String =
+    """Missing an instance of `CirceCodec` which means you're trying to use io.circe.Codec, but circe library is missing in your project config. If you want to have an instance of io.circe.Codec[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+
 }

--- a/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
@@ -11,6 +11,9 @@ object OrphanCirceInstances {
   final case class MyBox(id: Int, name: String, isActive: Boolean)
   object MyBox extends MyCirceInstances
 
+  final case class MyBoxForCodec(id: Int, name: String, isActive: Boolean)
+  object MyBoxForCodec extends MyCirceCodecInstances
+
   private[orphan_instance] trait MyCirceInstances extends MyCirceInstances1 {
     @nowarn213(
       """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
@@ -30,6 +33,17 @@ object OrphanCirceInstances {
     implicit def circeDecoder[F[*]: CirceDecoder]: F[MyBox] = {
       val myBoxDecoder: io.circe.Decoder[MyBox] = io.circe.generic.semiauto.deriveDecoder[MyBox]
       myBoxDecoder.asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+  }
+
+  private[orphan_instance] trait MyCirceCodecInstances extends OrphanCirce {
+    @nowarn213(
+      """msg=evidence parameter .+ of type (.+\.)*CirceCodec\[F\] in method circeCodec is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def circeCodec[F[*]: CirceCodec]: F[MyBoxForCodec] = {
+      val myBoxCodec: io.circe.Codec[MyBoxForCodec] = io.circe.generic.semiauto.deriveCodec[MyBoxForCodec]
+      myBoxCodec.asInstanceOf[F[MyBoxForCodec]] // scalafix:ok DisableSyntax.asInstanceOf
     }
   }
 

--- a/modules/orphan-circe-test/shared/src/main/scala-3/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-3/orphan_instance/OrphanCirceInstances.scala
@@ -11,6 +11,9 @@ object OrphanCirceInstances {
   final case class MyBox(id: Int, name: String, isActive: Boolean)
   object MyBox extends MyCirceInstances
 
+  final case class MyBoxForCodec(id: Int, name: String, isActive: Boolean)
+  object MyBoxForCodec extends MyCirceCodecInstances
+
   private[orphan_instance] trait MyCirceInstances extends MyCirceInstances1 {
     @nowarn(
       """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
@@ -29,6 +32,18 @@ object OrphanCirceInstances {
     given circeDecoder[F[*]: CirceDecoder]: F[MyBox] = {
       io.circe.generic.semiauto.deriveDecoder[MyBox].asInstanceOf[F[MyBox]] // scalafix:ok DisableSyntax.asInstanceOf
     }
+  }
+
+  private[orphan_instance] trait MyCirceCodecInstances extends OrphanCirce {
+    @nowarn(
+      """msg=evidence parameter .+ of type (.+\.)*CirceCodec\[F\] in method circeCodec is never used"""
+    )
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given circeCodec[F[*]: CirceCodec]: F[MyBoxForCodec] = {
+      val myBoxCodec: io.circe.Codec.AsObject[MyBoxForCodec] = io.circe.generic.semiauto.deriveCodec[MyBoxForCodec]
+      myBoxCodec.asInstanceOf[F[MyBoxForCodec]] // scalafix:ok DisableSyntax.asInstanceOf
+    }
+
   }
 
 }

--- a/modules/orphan-circe/shared/src/main/scala-2/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-2/orphan/OrphanCirce.scala
@@ -8,6 +8,7 @@ import scala.annotation.implicitNotFound
 trait OrphanCirce {
   final protected type CirceEncoder[F[*]] = OrphanCirce.CirceEncoder[F]
   final protected type CirceDecoder[F[*]] = OrphanCirce.CirceDecoder[F]
+  final protected type CirceCodec[F[*]]   = OrphanCirce.CirceCodec[F]
 }
 private[orphan] object OrphanCirce {
   @implicitNotFound(
@@ -33,6 +34,19 @@ private[orphan] object OrphanCirce {
   private[OrphanCirce] object CirceDecoder {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCirceDecoder: CirceDecoder[io.circe.Decoder] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CirceCodec` which means you're trying to use io.circe.Codec, " +
+      "but circe library is missing in your project config. " +
+      "If you want to have an instance of io.circe.Codec[A] provided, " +
+      """please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CirceCodec[F[*]]
+  private[OrphanCirce] object CirceCodec {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCirceCodec: CirceCodec[io.circe.Codec] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
@@ -8,6 +8,7 @@ import scala.annotation.implicitNotFound
 trait OrphanCirce {
   final protected type CirceEncoder[F[*]] = OrphanCirce.CirceEncoder[F]
   final protected type CirceDecoder[F[*]] = OrphanCirce.CirceDecoder[F]
+  final protected type CirceCodec[F[*]]   = OrphanCirce.CirceCodec[F]
 }
 private[orphan] object OrphanCirce {
   @implicitNotFound(
@@ -33,6 +34,28 @@ private[orphan] object OrphanCirce {
   private[OrphanCirce] object CirceDecoder {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCirceDecoder: CirceDecoder[io.circe.Decoder] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  final abstract private class CirceIsAvailable
+  private object CirceIsAvailable {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCirceIsAvailable[F[*]: CirceEncoder]: CirceIsAvailable =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CirceCodec` which means you're trying to use io.circe.Codec, " +
+      "but circe library is missing in your project config. " +
+      "If you want to have an instance of io.circe.Codec[A] provided, " +
+      """please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CirceCodec[F[*]]
+  private[OrphanCirce] object CirceCodec {
+    type CirceCodecEncoderDecoder[A] = io.circe.Codec[A] & io.circe.Encoder[A] & io.circe.Decoder[A]
+
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    given getCirceCodec(using circeIsAvailable: CirceIsAvailable): CirceCodec[CirceCodecEncoderDecoder] =
       null // scalafix:ok DisableSyntax.null
   }
 


### PR DESCRIPTION
## Close #43: [`orphan-circe`] Add `CirceCodec` for circe to `OrphanCirce`

- Introduce `CirceCodec[F[*]]` in `OrphanCirce` (Scala 2 and 3) with implicit/given bridges to `io.circe.Codec`, plus a dedicated compile-time missing-instance error message.
- Scala 3: add `CirceIsAvailable` gate and use a type intersection for: `io.circe.Codec[A] & io.circe.Encoder[A] & io.circe.Decoder[A]`. This was necessary because the provided `Codec[A]` instance for testing wasn't visible because compiler tried to look for `Encoder[A]` instead of `Codec[A]` although `Codec` is actually extending `Encoder` and `Decoder`.
- Add `MyBoxForCodec` and `MyCirceCodecInstances` with `circeCodec` derived via `io.circe.generic.semiauto.deriveCodec`:
  - Scala 2: `implicit def circeCodec[F[*]: CirceCodec]: F[MyBoxForCodec]`
  - Scala 3: `given circeCodec[F[*]: CirceCodec]: F[MyBoxForCodec]`
- Tests:
  - With Circe: new spec ensures the derived `Codec`-backed instance compiles/works.
  - Without Circe (Scala 2/3): new specs validate the compile-time error message when Circe is absent.
- Update `ExpectedMessages` with `ExpectedMessageForCirceCodec`.