### PR TITLE
Issue #43: [`orphan-circe`] Add `CirceCodec` for circe to `OrphanCirce` - Fix the names of test Specs

### DIFF
--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceDecoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceDecoderWithoutCirceSpec.scala
@@ -7,7 +7,7 @@ import hedgehog.runner.*
 /** @author Kevin Lee
   * @since 2025-08-10
   */
-object CirceDecoderWithCirceSpec extends Properties {
+object CirceDecoderWithoutCirceSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("testCirceDecoder", testCirceDecoder)

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceEncoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceEncoderWithoutCirceSpec.scala
@@ -7,7 +7,7 @@ import hedgehog.runner.*
 /** @author Kevin Lee
   * @since 2025-08-10
   */
-object CirceEncoderWithCirceSpec extends Properties {
+object CirceEncoderWithoutCirceSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("testCirceEncoder", testCirceEncoder)

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceDecoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceDecoderWithoutCirceSpec.scala
@@ -6,7 +6,7 @@ import hedgehog.runner.*
 /** @author Kevin Lee
   * @since 2025-08-10
   */
-object CirceDecoderWithCirceSpec extends Properties {
+object CirceDecoderWithoutCirceSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("testCirceDecoder", testCirceDecoder)

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceEncoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceEncoderWithoutCirceSpec.scala
@@ -6,7 +6,7 @@ import hedgehog.runner.*
 /** @author Kevin Lee
   * @since 2025-08-10
   */
-object CirceEncoderWithCirceSpec extends Properties {
+object CirceEncoderWithoutCirceSpec extends Properties {
 
   override def tests: List[Test] = List(
     example("testCirceEncoder", testCirceEncoder)


### PR DESCRIPTION
Issue #43: [`orphan-circe`] Add `CirceCodec` for circe to `OrphanCirce` - Fix the names of test Specs