### PR TITLE
Close #50: Support Scala Native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2.12", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
-          - { name: "Scala 2.13", version: "2.13.13", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
-          - { name: "Scala 3",    version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala 2.13", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala 3",    version: "3.3.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2.13", version: "2.13.13", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2.13", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         scala:
           - { name: "Scala 2.12", version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
-          - { name: "Scala 2.13", version: "2.13.13", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
-          - { name: "Scala 3",    version: "3.1.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala 2.13", version: "2.13.16", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala 3",    version: "3.3.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin" }
 
     steps:
       - uses: actions/checkout@v5

--- a/build.sbt
+++ b/build.sbt
@@ -41,53 +41,64 @@ lazy val orphan = (project in file("."))
   .aggregate(
     orphanCatsJvm,
     orphanCatsJs,
+    orphanCatsNative,
     orphanCatsTestWithoutCatsJvm,
     orphanCatsTestWithoutCatsJs,
+    orphanCatsTestWithoutCatsNative,
     orphanCatsTestWithCatsJvm,
     orphanCatsTestWithCatsJs,
+    orphanCatsTestWithCatsNative,
     orphanCirceJvm,
     orphanCirceJs,
+    orphanCirceNative,
     orphanCirceTestJvm,
     orphanCirceTestJs,
+    orphanCirceTestNative,
     orphanCirceTestWithoutCirceJvm,
     orphanCirceTestWithoutCirceJs,
+    orphanCirceTestWithoutCirceNative,
     orphanCirceTestWithCirceJvm,
     orphanCirceTestWithCirceJs,
+    orphanCirceTestWithCirceNative,
   )
 
-lazy val orphanCats    = module("cats", crossProject(JVMPlatform, JSPlatform))
+lazy val orphanCats       = module("cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
   .settings(
     libraryDependencies ++= List(libs.cats.value % Optional) ++ (
       if (isScala3(scalaVersion.value)) List.empty
       else
         List(
-          libs.scalacCompatAnnotation,
+//          libs.scalacCompatAnnotation,
           libs.tests.scalaReflect.value
         )
     ),
   )
-lazy val orphanCatsJvm = orphanCats.jvm
-lazy val orphanCatsJs  = orphanCats.js.settings(jsCommonSettings)
+lazy val orphanCatsJvm    = orphanCats.jvm
+lazy val orphanCatsJs     = orphanCats.js.settings(jsCommonSettings)
+lazy val orphanCatsNative = orphanCats.native.settings(nativeSettings)
 
-lazy val orphanCatsTestWithoutCats    = module("cats-test-without-cats", crossProject(JVMPlatform, JSPlatform))
-  .settings(noPublish)
-  .settings(
-    libraryDependencies ++= List(libs.tests.extrasTestingTools.value),
-  )
-  .dependsOn(orphanCats % props.IncludeTest)
-lazy val orphanCatsTestWithoutCatsJvm = orphanCatsTestWithoutCats.jvm
-lazy val orphanCatsTestWithoutCatsJs  = orphanCatsTestWithoutCats.js.settings(jsCommonSettings)
+lazy val orphanCatsTestWithoutCats       =
+  module("cats-test-without-cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
+    .settings(noPublish)
+    .settings(
+      libraryDependencies ++= List(libs.tests.extrasTestingTools.value),
+    )
+    .dependsOn(orphanCats % props.IncludeTest)
+lazy val orphanCatsTestWithoutCatsJvm    = orphanCatsTestWithoutCats.jvm
+lazy val orphanCatsTestWithoutCatsJs     = orphanCatsTestWithoutCats.js.settings(jsCommonSettings)
+lazy val orphanCatsTestWithoutCatsNative = orphanCatsTestWithoutCats.native.settings(nativeSettings)
 
-lazy val orphanCatsTestWithCats    = module("cats-test-with-cats", crossProject(JVMPlatform, JSPlatform))
+lazy val orphanCatsTestWithCats   = module("cats-test-with-cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
   .settings(noPublish)
   .settings(
     libraryDependencies ++= List(libs.cats.value % Test),
   )
   .dependsOn(orphanCats % props.IncludeTest)
 lazy val orphanCatsTestWithCatsJvm = orphanCatsTestWithCats.jvm
-lazy val orphanCatsTestWithCatsJs  = orphanCatsTestWithCats.js.settings(jsCommonSettings)
+lazy val orphanCatsTestWithCatsJs = orphanCatsTestWithCats.js.settings(jsCommonSettings)
+lazy val orphanCatsTestWithCatsNative = orphanCatsTestWithCats.native.settings(nativeSettings)
 
-lazy val orphanCirce    = module("circe", crossProject(JVMPlatform, JSPlatform))
+lazy val orphanCirce       = module("circe", crossProject(JVMPlatform, JSPlatform, NativePlatform))
   .settings(
     libraryDependencies ++= List(
       libs.circeCore.value % Optional,
@@ -95,47 +106,53 @@ lazy val orphanCirce    = module("circe", crossProject(JVMPlatform, JSPlatform))
       if (isScala3(scalaVersion.value)) List.empty
       else
         List(
-          libs.scalacCompatAnnotation,
+//          libs.scalacCompatAnnotation,
           libs.tests.scalaReflect.value
         )
     ),
   )
-lazy val orphanCirceJvm = orphanCirce.jvm
-lazy val orphanCirceJs  = orphanCirce.js.settings(jsCommonSettings)
+lazy val orphanCirceJvm    = orphanCirce.jvm
+lazy val orphanCirceJs     = orphanCirce.js.settings(jsCommonSettings)
+lazy val orphanCirceNative = orphanCirce.native.settings(nativeSettings)
 
-lazy val orphanCirceTest    = module("circe-test", crossProject(JVMPlatform, JSPlatform))
+lazy val orphanCirceTest       = module("circe-test", crossProject(JVMPlatform, JSPlatform, NativePlatform))
   .settings(noPublish)
   .settings(
     libraryDependencies ++= List(libs.circeGeneric.value % Optional),
   )
   .dependsOn(orphanCirce % props.IncludeTest)
-lazy val orphanCirceTestJvm = orphanCirceTest.jvm
-lazy val orphanCirceTestJs  = orphanCirceTest.js.settings(jsCommonSettings)
+lazy val orphanCirceTestJvm    = orphanCirceTest.jvm
+lazy val orphanCirceTestJs     = orphanCirceTest.js.settings(jsCommonSettings)
+lazy val orphanCirceTestNative = orphanCirceTest.native.settings(nativeSettings)
 
-lazy val orphanCirceTestWithoutCirce    = module("circe-test-without-circe", crossProject(JVMPlatform, JSPlatform))
-  .settings(noPublish)
-  .settings(
-    libraryDependencies ++= List(libs.tests.extrasTestingTools.value),
-    Test / libraryDependencies ~= (libs => libs.filterNot(_.name.startsWith("circe")))
-  )
-  .dependsOn(orphanCirceTest % props.IncludeTest)
-lazy val orphanCirceTestWithoutCirceJvm = orphanCirceTestWithoutCirce.jvm
-lazy val orphanCirceTestWithoutCirceJs  = orphanCirceTestWithoutCirce.js.settings(jsCommonSettings)
+lazy val orphanCirceTestWithoutCirce       =
+  module("circe-test-without-circe", crossProject(JVMPlatform, JSPlatform, NativePlatform))
+    .settings(noPublish)
+    .settings(
+      libraryDependencies ++= List(libs.tests.extrasTestingTools.value),
+      Test / libraryDependencies ~= (libs => libs.filterNot(_.name.startsWith("circe")))
+    )
+    .dependsOn(orphanCirceTest % props.IncludeTest)
+lazy val orphanCirceTestWithoutCirceJvm    = orphanCirceTestWithoutCirce.jvm
+lazy val orphanCirceTestWithoutCirceJs     = orphanCirceTestWithoutCirce.js.settings(jsCommonSettings)
+lazy val orphanCirceTestWithoutCirceNative = orphanCirceTestWithoutCirce.native.settings(nativeSettings)
 
-lazy val orphanCirceTestWithCirce    = module("circe-test-with-circe", crossProject(JVMPlatform, JSPlatform))
-  .settings(noPublish)
-  .settings(
-    libraryDependencies ++= List(
-      libs.circeCore.value    % Test,
-      libs.circeGeneric.value % Test,
-      libs.circeJawn.value    % Test,
-      libs.circeLiteral.value % Test,
-      libs.circeParser.value  % Test,
-    ),
-  )
-  .dependsOn(orphanCirceTest % props.IncludeTest)
-lazy val orphanCirceTestWithCirceJvm = orphanCirceTestWithCirce.jvm
-lazy val orphanCirceTestWithCirceJs  = orphanCirceTestWithCirce.js.settings(jsCommonSettings)
+lazy val orphanCirceTestWithCirce       =
+  module("circe-test-with-circe", crossProject(JVMPlatform, JSPlatform, NativePlatform))
+    .settings(noPublish)
+    .settings(
+      libraryDependencies ++= List(
+        libs.circeCore.value    % Test,
+        libs.circeGeneric.value % Test,
+        libs.circeJawn.value    % Test,
+        libs.circeLiteral.value % Test,
+        libs.circeParser.value  % Test,
+      ),
+    )
+    .dependsOn(orphanCirceTest % props.IncludeTest)
+lazy val orphanCirceTestWithCirceJvm    = orphanCirceTestWithCirce.jvm
+lazy val orphanCirceTestWithCirceJs     = orphanCirceTestWithCirce.js.settings(jsCommonSettings)
+lazy val orphanCirceTestWithCirceNative = orphanCirceTestWithCirce.native.settings(nativeSettings)
 
 lazy val props =
   new {
@@ -147,8 +164,8 @@ lazy val props =
     val GitHubUsername = GitHubRepo.fold("kevin-lee")(_.orgToString)
     val RepoName       = GitHubRepo.fold("orphan")(_.nameToString)
 
-    val Scala3Version      = "3.1.3"
-    val Scala2Version      = "2.13.13"
+    val Scala3Version      = "3.3.3"
+    val Scala2Version      = "2.13.16"
     val CrossScalaVersions = Seq(Scala2Version, "2.12.18", Scala3Version)
 
     val ProjectScalaVersion = Scala2Version
@@ -167,15 +184,15 @@ lazy val props =
 
     val XuweiKScalafixRulesVersion = "0.6.12"
 
-    val HedgehogVersion = "0.10.1"
+    val HedgehogVersion = "0.13.0"
 
-    val ExtrasVersion = "0.47.0"
+    val ExtrasVersion = "0.49.0"
 
-    val CatsVersion = "2.8.0"
+    val CatsVersion = "2.12.0"
 
     val ScalacCompatAnnotationVersion = "0.1.4"
 
-    val CirceVersion = "0.14.2"
+    val CirceVersion = "0.14.12"
 
   }
 
@@ -301,5 +318,10 @@ lazy val jsSettingsForFuture: SettingsDefinition = List(
                                         List(
                                           "-P:scalajs:nowarnGlobalExecutionContext"
                                         )),
+  coverageEnabled := false,
+)
+
+lazy val nativeSettings: SettingsDefinition = List(
+  Test / fork := false,
   coverageEnabled := false,
 )

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
@@ -1,6 +1,5 @@
 package orphan_instance
 
-import org.typelevel.scalaccompat.annotation.nowarn213
 import orphan.OrphanCats
 
 import scala.annotation.tailrec
@@ -58,9 +57,6 @@ object OrphanCatsInstances {
 
   final case class Another(n: Int)
   object Another extends OrphanCats {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[F\] in method catsShow is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsShow[F[*]: CatsShow]: F[Another] = new cats.Show[Another] {
       override def show(t: Another): String = s"Another(n=${t.n.toString})"
@@ -70,12 +66,6 @@ object OrphanCatsInstances {
 
   final case class Something[A](a: A)
   object Something extends OrphanCats {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[F\] in method catsShow is never used"""
-    )
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[G\] in method catsShow is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.ToString"))
     implicit def catsShow[F[*]: CatsShow, A, G[*]: CatsShow](implicit g: G[A]): F[Something[A]] = {
       implicit val showA: cats.Show[A] = g.asInstanceOf[cats.Show[A]] // scalafix:ok DisableSyntax.asInstanceOf
@@ -130,9 +120,6 @@ object OrphanCatsInstances {
   }
 
   private[orphan_instance] trait MyCatsInstances extends MyCatsInstances1 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsFunctor\[F\] in method catsFunctor is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsFunctor[F[*[*]]: CatsFunctor]: F[MyBox] = new cats.Functor[MyBox] {
       override def map[A, B](fa: MyBox[A])(f: A => B): MyBox[B] = fa.copy(f(fa.a))
@@ -140,9 +127,6 @@ object OrphanCatsInstances {
   }
 
   private[orphan_instance] trait MyCatsInstances1 extends MyCatsInstances2 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsApplicative\[F\] in method catsApplicative is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsApplicative[F[*[*]]: CatsApplicative]: F[MyBox] = new cats.Applicative[MyBox] {
       override def pure[A](a: A): MyBox[A] = MyBox(a)
@@ -152,9 +136,6 @@ object OrphanCatsInstances {
   }
 
   private[orphan_instance] trait MyCatsInstances2 extends MyCatsInstances3 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsMonad\[F\] in method catsMonad is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsMonad[F[*[*]]: CatsMonad]: F[MyBox] = new cats.Monad[MyBox] {
       override def pure[A](x: A): MyBox[A] = MyBox(x)
@@ -170,9 +151,6 @@ object OrphanCatsInstances {
   }
 
   private[orphan_instance] trait MyCatsInstances3 extends MyCatsInstances4 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsTraverse\[F\] in method catsTraverse is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsTraverse[F[*[*]]: CatsTraverse]: F[MyBox] = new cats.Traverse[MyBox] {
       override def traverse[G[_]: cats.Applicative, A, B](fa: MyBox[A])(f: A => G[B]): G[MyBox[B]] =
@@ -186,12 +164,6 @@ object OrphanCatsInstances {
   }
 
   private[orphan_instance] trait MyCatsInstances4 extends OrphanCats {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[F\] in method catsShow is never used"""
-    )
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsShow\[G\] in method catsShow is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsShow[F[*]: CatsShow, A, G[*]: CatsShow](implicit g: G[A]): F[MyBox[A]] = {
       implicit val showA: cats.Show[A] = g.asInstanceOf[cats.Show[A]] // scalafix:ok DisableSyntax.asInstanceOf

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsKernelInstances.scala
@@ -1,6 +1,5 @@
 package orphan_instance
 
-import org.typelevel.scalaccompat.annotation.nowarn213
 import orphan.OrphanCatsKernel
 
 /** @author Kevin Lee
@@ -77,9 +76,6 @@ object OrphanCatsKernelInstances {
   }
 
   private[orphan_instance] trait MyCatsKernelInstances extends MyCatsKernelInstances1 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsSemigroup\[F\] in method catsSemigroup is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsSemigroup[F[*]: CatsSemigroup]: F[MyNum] = new cats.kernel.Semigroup[MyNum] {
       override def combine(x: MyNum, y: MyNum): MyNum = MyNum(x.n + y.n)
@@ -87,9 +83,6 @@ object OrphanCatsKernelInstances {
   }
 
   private[orphan_instance] trait MyCatsKernelInstances1 extends MyCatsKernelInstances2 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsMonoid\[F\] in method catsMonoid is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsMonoid[F[*]: CatsMonoid]: F[MyNum] = new cats.kernel.Monoid[MyNum] {
       override def empty: MyNum = MyNum(0)
@@ -99,9 +92,6 @@ object OrphanCatsKernelInstances {
   }
 
   private[orphan_instance] trait MyCatsKernelInstances2 extends MyCatsKernelInstances3 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsEq\[F\] in method catsEq is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsEq[F[*]: CatsEq]: F[MyNum] = new cats.kernel.Eq[MyNum] {
       override def eqv(x: MyNum, y: MyNum): Boolean = cats.kernel.Eq[Int].eqv(x.n, y.n)
@@ -109,9 +99,6 @@ object OrphanCatsKernelInstances {
   }
 
   private[orphan_instance] trait MyCatsKernelInstances3 extends MyCatsKernelInstances4 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsHash\[F\] in method catsHash is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsHash[F[*]: CatsHash]: F[MyNum] = new cats.kernel.Hash[MyNum] {
       override def hash(x: MyNum): Int = x.##
@@ -121,9 +108,6 @@ object OrphanCatsKernelInstances {
   }
 
   private[orphan_instance] trait MyCatsKernelInstances4 extends OrphanCatsKernel {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CatsOrder\[F\] in method catsOrder is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def catsOrder[F[*]: CatsOrder]: F[MyNum] = new cats.kernel.Order[MyNum] {
       override def compare(x: MyNum, y: MyNum): Int = x.n.compare(y.n)

--- a/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
+++ b/modules/orphan-circe-test/shared/src/main/scala-2/orphan_instance/OrphanCirceInstances.scala
@@ -1,6 +1,5 @@
 package orphan_instance
 
-import org.typelevel.scalaccompat.annotation.nowarn213
 import orphan.OrphanCirce
 
 /** @author Kevin Lee
@@ -15,9 +14,6 @@ object OrphanCirceInstances {
   object MyBoxForCodec extends MyCirceCodecInstances
 
   private[orphan_instance] trait MyCirceInstances extends MyCirceInstances1 {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CirceEncoder\[F\] in method circeEncoder is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def circeEncoder[F[*]: CirceEncoder]: F[MyBox] = {
       val myBoxEncoder: io.circe.Encoder[MyBox] = io.circe.generic.semiauto.deriveEncoder[MyBox]
@@ -26,9 +22,6 @@ object OrphanCirceInstances {
   }
 
   private[orphan_instance] trait MyCirceInstances1 extends OrphanCirce {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CirceDecoder\[F\] in method circeDecoder is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def circeDecoder[F[*]: CirceDecoder]: F[MyBox] = {
       val myBoxDecoder: io.circe.Decoder[MyBox] = io.circe.generic.semiauto.deriveDecoder[MyBox]
@@ -37,9 +30,6 @@ object OrphanCirceInstances {
   }
 
   private[orphan_instance] trait MyCirceCodecInstances extends OrphanCirce {
-    @nowarn213(
-      """msg=evidence parameter .+ of type (.+\.)*CirceCodec\[F\] in method circeCodec is never used"""
-    )
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     implicit def circeCodec[F[*]: CirceCodec]: F[MyBoxForCodec] = {
       val myBoxCodec: io.circe.Codec[MyBoxForCodec] = io.circe.generic.semiauto.deriveCodec[MyBoxForCodec]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,14 +4,17 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.2.7")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.11.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.4")
 addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.17.0")
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.16.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.18.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
-val sbtDevOopsVersion = "3.2.1"
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.8")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+
+val sbtDevOopsVersion     = "3.2.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
## Close #50: Support Scala Native

- Support Scala Native for orphan-cats and orphan-circe
- remove unused `@nowarn213` imports and annotations and update build plugins
- Update `sbt-scalajs` from `1.16.0` to `1.18.2`
- Add Scala Native support with `sbt-scala-native` `0.5.8` and crossproject plugin