### PR TITLE
orphan v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,41 @@
+## [0.2.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am2) - 2025-08-20
+
+### New Features
+
+* [`orphan-circe`] Add `OrphanCirce` with `CirceEncoder` for circe support (#41)
+
+  Add
+  - [x] `OrphanCirce` containing
+    - [x] `CirceEncoder`
+  - [x] For testing, `OrphanCirceInstances`
+    - [x] an `io.circe.Encoder` instance for testing
+  - [x] Add a test module with circe
+    - [x] Add a test for `CirceEncoder`
+  - [x] Add a test module without circe
+    - [x] Add a test for `CirceEncoder`
+***
+* [`orphan-circe`] Add `CirceDecoder` for circe to `OrphanCirce` (#42)
+
+  Add
+  - [x] `CirceDecoder` to `OrphanCirce`
+  
+  For testing, in `OrphanCirceInstances`,
+  - [x] an `io.circe.Decoder` instance
+  - [x] Add a test for `CirceDecoder` in the test module with circe
+  - [x] Add a test for `CirceDecoder` in the test module without circe
+***
+* [`orphan-circe`] Add `CirceCodec` for circe to `OrphanCirce` (#43)
+
+  Add
+  - [x] `CirceCodec` to `OrphanCirce`
+  
+  For testing, in `OrphanCirceInstances`,
+  - [x] an `io.circe.Codec` instance
+  - [x] Add a test for `CirceCodec` in the test module with circe
+  - [x] Add a test for `CirceCodec` in the test module without circe
+***
+* Support Scala Native (#50)
+
+### Internal Housekeeping
+
+* Replace `orphan.testing.CompileTimeError` with `extras.testing.CompileTimeError` from `extras-testing-tools` (#39)


### PR DESCRIPTION
# orphan v0.2.0
## [0.2.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am2) - 2025-08-20

### New Features

* [`orphan-circe`] Add `OrphanCirce` with `CirceEncoder` for circe support (#41)

  Add
  - [x] `OrphanCirce` containing
    - [x] `CirceEncoder`
  - [x] For testing, `OrphanCirceInstances`
    - [x] an `io.circe.Encoder` instance for testing
  - [x] Add a test module with circe
    - [x] Add a test for `CirceEncoder`
  - [x] Add a test module without circe
    - [x] Add a test for `CirceEncoder`
***
* [`orphan-circe`] Add `CirceDecoder` for circe to `OrphanCirce` (#42)

  Add
  - [x] `CirceDecoder` to `OrphanCirce`
  
  For testing, in `OrphanCirceInstances`,
  - [x] an `io.circe.Decoder` instance
  - [x] Add a test for `CirceDecoder` in the test module with circe
  - [x] Add a test for `CirceDecoder` in the test module without circe
***
* [`orphan-circe`] Add `CirceCodec` for circe to `OrphanCirce` (#43)

  Add
  - [x] `CirceCodec` to `OrphanCirce`
  
  For testing, in `OrphanCirceInstances`,
  - [x] an `io.circe.Codec` instance
  - [x] Add a test for `CirceCodec` in the test module with circe
  - [x] Add a test for `CirceCodec` in the test module without circe
***
* Support Scala Native (#50)

### Internal Housekeeping

* Replace `orphan.testing.CompileTimeError` with `extras.testing.CompileTimeError` from `extras-testing-tools` (#39)
