### PR TITLE
Close #55: [`orphan-cats`] Add `CatsContravariant` for `cats.Contravariant`

### DIFF
--- a/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsContravariantWithCatsSpec.scala
+++ b/modules/orphan-cats-test-with-cats/shared/src/test/scala/orphan_test/CatsContravariantWithCatsSpec.scala
@@ -1,0 +1,77 @@
+package orphan_test
+
+import cats.Contravariant
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyContravariant, MyEncoder}
+
+/** @author Kevin Lee
+  * @since 2025-08-21
+  */
+object CatsContravariantWithCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyContravariant.imap", testMyContravariantImap),
+    property("test MyContravariant.contramap", testMyContravariantContramap),
+    property("test CatsContravariant.imap", testCatsContravariantImap),
+    property("test CatsContravariant.contramap", testCatsContravariantContramap),
+  )
+
+  def testMyContravariantImap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   =
+      MyContravariant[MyEncoder].imap(myEncoder)(a => MyBox((a.a + 999).toString))(a => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testMyContravariantContramap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   = MyContravariant[MyEncoder].contramap(myEncoder)((a: MyBox[String]) => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testCatsContravariantImap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual = Contravariant[MyEncoder].imap(myEncoder)(a => MyBox((a.a + 999).toString))(a => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testCatsContravariantContramap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   = Contravariant[MyEncoder].contramap(myEncoder)((a: MyBox[String]) => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsContravariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsContravariantWithoutCatsSpec.scala
@@ -1,0 +1,60 @@
+package orphan_test
+
+import extras.testing.CompileTimeError
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyContravariant, MyEncoder}
+
+/** @author Kevin Lee
+  * @since 2025-08-21
+  */
+object CatsContravariantWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyContravariant.imap", testMyContravariantImap),
+    property("test MyContravariant.contramap", testMyContravariantContramap),
+    example("test CatsContravariant", testCatsContravariant),
+  )
+
+  def testMyContravariantImap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   =
+      MyContravariant[MyEncoder].imap(myEncoder)(a => MyBox((a.a + 999).toString))(a => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testMyContravariantContramap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   = MyContravariant[MyEncoder].contramap(myEncoder)((a: MyBox[String]) => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testCatsContravariant: Result = {
+
+    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCatsContravariant}
+                      |orphan_instance.OrphanCatsInstances.MyEncoder.catsContravariant
+                      |                                              ^""".stripMargin
+
+    val actual = CompileTimeError.from(
+      "orphan_instance.OrphanCatsInstances.MyEncoder.catsContravariant"
+    )
+    actual ==== expected
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsContravariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsContravariantWithoutCatsSpec.scala
@@ -1,0 +1,62 @@
+package orphan_test
+
+import hedgehog.*
+import hedgehog.runner.*
+import orphan_instance.OrphanCatsInstances.{MyBox, MyContravariant, MyEncoder}
+
+/** @author Kevin Lee
+  * @since 2025-08-21
+  */
+object CatsContravariantWithoutCatsSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test MyContravariant.imap", testMyContravariantImap),
+    property("test MyContravariant.contramap", testMyContravariantContramap),
+    example("test CatsContravariant", testCatsContravariant),
+  )
+
+  def testMyContravariantImap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   =
+      MyContravariant[MyEncoder].imap(myEncoder)(a => MyBox((a.a + 999).toString))(a => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testMyContravariantContramap: Property = for {
+    n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+    myBox <- Gen.constant(MyBox(n)).log("myBox")
+  } yield {
+    val myEncoder = new MyEncoder[MyBox[Int]] {
+      override def encode(value: MyBox[Int]): String = s"Result(a=${(value.a + 999).toString})"
+    }
+
+    val input    = myBox.copy(a = myBox.a.toString)
+    val expected = s"Result(a=${n.toString})"
+    val actual   = MyContravariant[MyEncoder].contramap(myEncoder)((a: MyBox[String]) => MyBox(a.a.toInt - 999))
+    actual.encode(input) ==== expected
+  }
+
+  def testCatsContravariant: Result = {
+
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = ExpectedMessages.ExpectedMessageForCatsContravariant
+
+    val actual = typeCheckErrors(
+      """
+        val _ =  orphan_instance.OrphanCatsInstances.MyEncoder.catsContravariant
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala/orphan_test/ExpectedMessages.scala
@@ -11,6 +11,9 @@ object ExpectedMessages {
   val ExpectedMessageForCatsInvariant: String =
     """Missing an instance of `CatsInvariant` which means you're trying to use cats.Invariant, but cats library is missing in your project config. If you want to have an instance of cats.Invariant[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
+  val ExpectedMessageForCatsContravariant: String =
+    """Missing an instance of `CatsContravariant` which means you're trying to use cats.Contravariant, but cats library is missing in your project config. If you want to have an instance of cats.Contravariant[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+
   val ExpectedMessageForCatsFunctor: String =
     """Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, but cats library is missing in your project config. If you want to have an instance of cats.Functor[F[*]] provided, please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -8,7 +8,8 @@ import scala.annotation.implicitNotFound
 trait OrphanCats {
   final protected type CatsShow[F[*]] = OrphanCats.CatsShow[F]
 
-  final protected type CatsInvariant[F[*[*]]] = OrphanCats.CatsInvariant[F]
+  final protected type CatsInvariant[F[*[*]]]     = OrphanCats.CatsInvariant[F]
+  final protected type CatsContravariant[F[*[*]]] = OrphanCats.CatsContravariant[F]
 
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
@@ -40,6 +41,19 @@ private[orphan] object OrphanCats {
   private[OrphanCats] object CatsInvariant {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     @inline implicit final def getCatsInvariant: CatsInvariant[cats.Invariant] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsContravariant` which means you're trying to use cats.Contravariant, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Contravariant[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsContravariant[F[*[*]]]
+  private[OrphanCats] object CatsContravariant {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsContravariant: CatsContravariant[cats.Contravariant] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -8,7 +8,8 @@ import scala.annotation.implicitNotFound
 trait OrphanCats {
   final protected type CatsShow[F[*]] = OrphanCats.CatsShow[F]
 
-  final protected type CatsInvariant[F[*[*]]] = OrphanCats.CatsInvariant[F]
+  final protected type CatsInvariant[F[*[*]]]     = OrphanCats.CatsInvariant[F]
+  final protected type CatsContravariant[F[*[*]]] = OrphanCats.CatsContravariant[F]
 
   final protected type CatsFunctor[F[*[*]]]     = OrphanCats.CatsFunctor[F]
   final protected type CatsApplicative[F[*[*]]] = OrphanCats.CatsApplicative[F]
@@ -27,6 +28,19 @@ private[orphan] object OrphanCats {
   private[OrphanCats] object CatsShow {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsShow: CatsShow[cats.Show] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @implicitNotFound(
+    msg = "Missing an instance of `CatsContravariant` which means you're trying to use cats.Contravariant, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Contravariant[F[*]] provided, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed protected trait CatsContravariant[F[*[*]]]
+  private[OrphanCats] object CatsContravariant {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    final inline given getCatsContravariant: CatsContravariant[cats.Contravariant] =
       null // scalafix:ok DisableSyntax.null
   }
 

--- a/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
+++ b/modules/orphan-cats/shared/src/test/scala-2/orphan_instance/OrphanCatsInstances.scala
@@ -23,6 +23,14 @@ object OrphanCatsInstances {
     def apply[F[*]: MyInvariant]: MyInvariant[F] = implicitly[MyInvariant[F]]
   }
 
+  trait MyContravariant[F[*]] extends MyInvariant[F] {
+    def contramap[A, B](fa: F[A])(f: B => A): F[B]
+    override def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B] = contramap(fa)(fi)
+  }
+  object MyContravariant {
+    def apply[F[*]: MyContravariant]: MyContravariant[F] = implicitly[MyContravariant[F]]
+  }
+
   trait MyFunctor[F[*]] {
     def map[A, B](fa: F[A])(f: A => B): F[B]
   }
@@ -189,6 +197,28 @@ object OrphanCatsInstances {
         override def show(t: MyBox[A]): String = s"MyBox(a=${showA.show(t.a)})"
       }.asInstanceOf[F[MyBox[A]]] // scalafix:ok DisableSyntax.asInstanceOf
     }
+  }
+
+  trait MyEncoder[A] {
+    def encode(value: A): String
+  }
+  object MyEncoder extends OrphanCats {
+
+    def apply[A: MyEncoder]: MyEncoder[A] = implicitly[MyEncoder[A]]
+
+    implicit def myContravariantMyEncoder: MyContravariant[MyEncoder] = new MyContravariant[MyEncoder] {
+      override def contramap[A, B](fa: MyEncoder[A])(f: B => A): MyEncoder[B] = new MyEncoder[B] {
+        override def encode(value: B): String = fa.encode(f(value))
+      }
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    implicit def catsContravariant[F[*[*]]: CatsContravariant]: F[MyEncoder] = new cats.Contravariant[MyEncoder] {
+      override def contramap[A, B](fa: MyEncoder[A])(f: B => A): MyEncoder[B] = new MyEncoder[B] {
+        override def encode(value: B): String = fa.encode(f(value))
+      }
+    }.asInstanceOf[F[MyEncoder]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
 }


### PR DESCRIPTION
## Close #55: [`orphan-cats`] Add `CatsContravariant` for `cats.Contravariant`

- Add `CatsContravariant` to `OrphanCats`
  - Include proper `@implicitNotFound` annotations for better error messages
- Add `MyContravariant` trait and companion object for both Scala 2 and 3 for testing
- Implement `MyContravariant` and `cats.Contravariant` instance for `MyEncoder` type-class for testing