### PR TITLE
Close #65: Rename `ExpectedMessages` in `orphan-cats` and its fields

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ ignore:
   - "docs"
   - "generated-docs"
   - "website"
-  - "**/ExpectedMessages.scala"
+  - "**/OrphanCatsMessages.scala"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsApplicativeWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsApplicativeWithoutCatsSpec.scala
@@ -47,7 +47,7 @@ object CatsApplicativeWithoutCatsSpec extends Properties {
   }
 
   def testCatsApplicative: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsApplicative}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsApplicative}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsApplicative
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsContravariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsContravariantWithoutCatsSpec.scala
@@ -63,7 +63,7 @@ object CatsContravariantWithoutCatsSpec extends Properties {
 
   def testCatsContravariant: Result = {
 
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsContravariant}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsContravariant}
                       |orphan_instance.OrphanCatsInstances.MyEncoder.catsContravariant
                       |                                              ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsEqWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsEqWithoutCatsSpec.scala
@@ -39,7 +39,7 @@ object CatsEqWithoutCatsSpec extends Properties {
   }
 
   def testCatsEq: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsEq}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsEq}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsEq
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsFunctorWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsFunctorWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsFunctorWithoutCatsSpec extends Properties {
   }
 
   def testCatsFunctor: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsFunctor}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsFunctor}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsFunctor
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsHashWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsHashWithoutCatsSpec.scala
@@ -49,7 +49,7 @@ object CatsHashWithoutCatsSpec extends Properties {
   }
 
   def testCatsHash: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsHash}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsHash}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsHash
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsInvariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsInvariantWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsInvariantWithoutCatsSpec extends Properties {
   }
 
   def testCatsInvariant: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsInvariant}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsInvariant}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsInvariant
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonadWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonadWithoutCatsSpec.scala
@@ -36,7 +36,7 @@ object CatsMonadWithoutCatsSpec extends Properties {
   }
 
   def testCatsMonad: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsMonad}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsMonad}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsMonad
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonoidWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonoidWithoutCatsSpec.scala
@@ -35,7 +35,7 @@ object CatsMonoidWithoutCatsSpec extends Properties {
   }
 
   def testCatsMonoid: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsMonoid}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsMonoid}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsMonoid
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsOrderWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsOrderWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsOrderWithoutCatsSpec extends Properties {
   }
 
   def testCatsOrder: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsOrder}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsOrder}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsOrder
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsSemigroupWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsSemigroupWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsSemigroupWithoutCatsSpec extends Properties {
   }
 
   def testCatsSemigroup: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsSemigroup}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsSemigroup}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsSemigroup
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsShowWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsShowWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsShowWithoutCatsSpec extends Properties {
   }
 
   def testCatsShow: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsShow}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsShow}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsShow
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsTraverseWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsTraverseWithoutCatsSpec.scala
@@ -58,7 +58,7 @@ object CatsTraverseWithoutCatsSpec extends Properties {
   }
 
   def testCatsTraverse: Result = {
-    val expected = s"""error: ${orphan.ExpectedMessages.ExpectedMessageForCatsTraverse}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsTraverse}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsTraverse
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsApplicativeWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsApplicativeWithoutCatsSpec.scala
@@ -47,7 +47,7 @@ object CatsApplicativeWithoutCatsSpec extends Properties {
 
   def testCatsApplicative: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsApplicative
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsApplicative
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsContravariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsContravariantWithoutCatsSpec.scala
@@ -63,7 +63,7 @@ object CatsContravariantWithoutCatsSpec extends Properties {
   def testCatsContravariant: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsContravariant
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsContravariant
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsEqWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsEqWithoutCatsSpec.scala
@@ -39,7 +39,7 @@ object CatsEqWithoutCatsSpec extends Properties {
 
   def testCatsEq: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsEq
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsEq
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsFunctorWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsFunctorWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsFunctorWithoutCatsSpec extends Properties {
 
   def testCatsFunctor: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsFunctor
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsFunctor
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsHashWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsHashWithoutCatsSpec.scala
@@ -49,7 +49,7 @@ object CatsHashWithoutCatsSpec extends Properties {
 
   def testCatsHash: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsHash
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsHash
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsInvariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsInvariantWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsInvariantWithoutCatsSpec extends Properties {
 
   def testCatsInvariant: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsInvariant
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsInvariant
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonadWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonadWithoutCatsSpec.scala
@@ -36,7 +36,7 @@ object CatsMonadWithoutCatsSpec extends Properties {
 
   def testCatsMonad: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsMonad
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsMonad
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonoidWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonoidWithoutCatsSpec.scala
@@ -36,7 +36,7 @@ object CatsMonoidWithoutCatsSpec extends Properties {
   def testCatsMonoid: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsMonoid
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsMonoid
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsOrderWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsOrderWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsOrderWithoutCatsSpec extends Properties {
 
   def testCatsOrder: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsOrder
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsOrder
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsSemigroupWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsSemigroupWithoutCatsSpec.scala
@@ -28,7 +28,7 @@ object CatsSemigroupWithoutCatsSpec extends Properties {
   def testCatsSemigroup: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsSemigroup
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsSemigroup
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsShowWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsShowWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsShowWithoutCatsSpec extends Properties {
 
   def testCatsShow: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsShow
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsShow
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsTraverseWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsTraverseWithoutCatsSpec.scala
@@ -58,7 +58,7 @@ object CatsTraverseWithoutCatsSpec extends Properties {
 
   def testCatsTraverse: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.ExpectedMessages.ExpectedMessageForCatsTraverse
+    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsTraverse
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -19,7 +19,7 @@ trait OrphanCats {
 private[orphan] object OrphanCats {
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsShow
+    msg = OrphanCatsMessages.MisingCatsShow
   )
   sealed protected trait CatsShow[F[*]]
   private[OrphanCats] object CatsShow {
@@ -29,7 +29,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsInvariant
+    msg = OrphanCatsMessages.MisingCatsInvariant
   )
   sealed protected trait CatsInvariant[F[*[*]]]
   private[OrphanCats] object CatsInvariant {
@@ -39,7 +39,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsContravariant
+    msg = OrphanCatsMessages.MisingCatsContravariant
   )
   sealed protected trait CatsContravariant[F[*[*]]]
   private[OrphanCats] object CatsContravariant {
@@ -49,7 +49,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsFunctor
+    msg = OrphanCatsMessages.MisingCatsFunctor
   )
   sealed protected trait CatsFunctor[F[*[*]]]
   private[OrphanCats] object CatsFunctor {
@@ -59,7 +59,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsApplicative
+    msg = OrphanCatsMessages.MisingCatsApplicative
   )
   sealed protected trait CatsApplicative[F[*[*]]]
   private[OrphanCats] object CatsApplicative {
@@ -69,7 +69,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsMonad
+    msg = OrphanCatsMessages.MisingCatsMonad
   )
   sealed protected trait CatsMonad[F[*[*]]]
   private[OrphanCats] object CatsMonad {
@@ -79,7 +79,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsTraverse
+    msg = OrphanCatsMessages.MisingCatsTraverse
   )
   sealed protected trait CatsTraverse[F[*[*]]]
   private[OrphanCats] object CatsTraverse {

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -15,7 +15,7 @@ trait OrphanCatsKernel {
 private[orphan] object OrphanCatsKernel {
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsSemigroup
+    msg = OrphanCatsMessages.MisingCatsSemigroup
   )
   sealed protected trait CatsSemigroup[F[*]]
   private[OrphanCatsKernel] object CatsSemigroup {
@@ -25,7 +25,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsMonoid
+    msg = OrphanCatsMessages.MisingCatsMonoid
   )
   sealed protected trait CatsMonoid[F[*]]
   private[OrphanCatsKernel] object CatsMonoid {
@@ -35,7 +35,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsEq
+    msg = OrphanCatsMessages.MisingCatsEq
   )
   sealed protected trait CatsEq[F[*]]
   private[OrphanCatsKernel] object CatsEq {
@@ -45,7 +45,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsHash
+    msg = OrphanCatsMessages.MisingCatsHash
   )
   sealed protected trait CatsHash[F[*]]
   private[OrphanCatsKernel] object CatsHash {
@@ -55,7 +55,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsOrder
+    msg = OrphanCatsMessages.MisingCatsOrder
   )
   sealed protected trait CatsOrder[F[*]]
   private[OrphanCatsKernel] object CatsOrder {

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -19,7 +19,7 @@ trait OrphanCats {
 private[orphan] object OrphanCats {
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsShow
+    msg = OrphanCatsMessages.MisingCatsShow
   )
   sealed protected trait CatsShow[F[*]]
   private[OrphanCats] object CatsShow {
@@ -29,7 +29,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsInvariant
+    msg = OrphanCatsMessages.MisingCatsInvariant
   )
   sealed protected trait CatsInvariant[F[*[*]]]
   private[OrphanCats] object CatsInvariant {
@@ -39,7 +39,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsContravariant
+    msg = OrphanCatsMessages.MisingCatsContravariant
   )
   sealed protected trait CatsContravariant[F[*[*]]]
   private[OrphanCats] object CatsContravariant {
@@ -49,7 +49,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsFunctor
+    msg = OrphanCatsMessages.MisingCatsFunctor
   )
   sealed protected trait CatsFunctor[F[*[*]]]
   private[OrphanCats] object CatsFunctor {
@@ -59,7 +59,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsApplicative
+    msg = OrphanCatsMessages.MisingCatsApplicative
   )
   sealed protected trait CatsApplicative[F[*[*]]]
   private[OrphanCats] object CatsApplicative {
@@ -69,7 +69,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsMonad
+    msg = OrphanCatsMessages.MisingCatsMonad
   )
   sealed protected trait CatsMonad[F[*[*]]]
   private[OrphanCats] object CatsMonad {
@@ -79,7 +79,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsTraverse
+    msg = OrphanCatsMessages.MisingCatsTraverse
   )
   sealed protected trait CatsTraverse[F[*[*]]]
   private[OrphanCats] object CatsTraverse {

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -15,7 +15,7 @@ trait OrphanCatsKernel {
 private[orphan] object OrphanCatsKernel {
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsSemigroup
+    msg = OrphanCatsMessages.MisingCatsSemigroup
   )
   sealed protected trait CatsSemigroup[F[*]]
   private[OrphanCatsKernel] object CatsSemigroup {
@@ -25,7 +25,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsMonoid
+    msg = OrphanCatsMessages.MisingCatsMonoid
   )
   sealed protected trait CatsMonoid[F[*]]
   private[OrphanCatsKernel] object CatsMonoid {
@@ -35,7 +35,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsEq
+    msg = OrphanCatsMessages.MisingCatsEq
   )
   sealed protected trait CatsEq[F[*]]
   private[OrphanCatsKernel] object CatsEq {
@@ -45,7 +45,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsHash
+    msg = OrphanCatsMessages.MisingCatsHash
   )
   sealed protected trait CatsHash[F[*]]
   private[OrphanCatsKernel] object CatsHash {
@@ -55,7 +55,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = ExpectedMessages.ExpectedMessageForCatsOrder
+    msg = OrphanCatsMessages.MisingCatsOrder
   )
   sealed protected trait CatsOrder[F[*]]
   private[OrphanCatsKernel] object CatsOrder {

--- a/modules/orphan-cats/shared/src/main/scala/orphan/OrphanCatsMessages.scala
+++ b/modules/orphan-cats/shared/src/main/scala/orphan/OrphanCatsMessages.scala
@@ -4,76 +4,76 @@ package orphan
   * @since 2025-07-28
   */
 @SuppressWarnings(Array("org.wartremover.warts.FinalVal", "org.wartremover.warts.PublicInference"))
-object ExpectedMessages {
+object OrphanCatsMessages {
   // scalafix:off DisableSyntax.noFinalVal
 
-  final val ExpectedMessageForCatsShow =
+  final val MisingCatsShow =
     """Missing an instance of `CatsShow` which means you're trying to use cats.Show, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Show[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsInvariant =
+  final val MisingCatsInvariant =
     """Missing an instance of `CatsInvariant` which means you're trying to use cats.Invariant, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Invariant[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsContravariant =
+  final val MisingCatsContravariant =
     """Missing an instance of `CatsContravariant` which means you're trying to use cats.Contravariant, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Contravariant[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsFunctor =
+  final val MisingCatsFunctor =
     """Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Functor[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsApplicative =
+  final val MisingCatsApplicative =
     """Missing an instance of `CatsApplicative` which means you're trying to use cats.Applicative, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Applicative[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsMonad =
+  final val MisingCatsMonad =
     """Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Monad[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsTraverse =
+  final val MisingCatsTraverse =
     """Missing an instance of `CatsTraverse` which means you're trying to use cats.Traverse, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Traverse[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsSemigroup =
+  final val MisingCatsSemigroup =
     """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Semigroup[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsMonoid =
+  final val MisingCatsMonoid =
     """Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Monoid[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsEq =
+  final val MisingCatsEq =
     """Missing an instance of `CatsEq` which means you're trying to use cats.kernel.Eq, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Eq[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsHash =
+  final val MisingCatsHash =
     """Missing an instance of `CatsHash` which means you're trying to use cats.kernel.Hash, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Hash[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val ExpectedMessageForCatsOrder =
+  final val MisingCatsOrder =
     """Missing an instance of `CatsOrder` which means you're trying to use cats.kernel.Order, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Order[A] provided, """ +

--- a/modules/orphan-cats/shared/src/test/scala/orphan/OrphanCatsMessagesSpec.scala
+++ b/modules/orphan-cats/shared/src/test/scala/orphan/OrphanCatsMessagesSpec.scala
@@ -6,59 +6,62 @@ import hedgehog.runner.*
 /** @author Kevin Lee
   * @since 2025-08-23
   */
-object ExpectedMessagesSpec extends Properties {
+object OrphanCatsMessagesSpec extends Properties {
   private val ExpectedDependency = "\"org.typelevel\" %% \"cats-core\" % CATS_VERSION"
 
   override def tests: List[Test] = List(
     example(
-      "ExpectedMessages.ExpectedMessageForCatsShow should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsShow should contain expected strings",
       testExpectedMessageForCatsShow
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsInvariant should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsInvariant should contain expected strings",
       testExpectedMessageForCatsInvariant
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsContravariant should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsContravariant should contain expected strings",
       testExpectedMessageForCatsContravariant
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsFunctor should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsFunctor should contain expected strings",
       testExpectedMessageForCatsFunctor
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsApplicative should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsApplicative should contain expected strings",
       testExpectedMessageForCatsApplicative
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsMonad should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsMonad should contain expected strings",
       testExpectedMessageForCatsMonad
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsTraverse should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsTraverse should contain expected strings",
       testExpectedMessageForCatsTraverse
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsSemigroup should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsSemigroup should contain expected strings",
       testExpectedMessageForCatsSemigroup
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsMonoid should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsMonoid should contain expected strings",
       testExpectedMessageForCatsMonoid
     ),
-    example("ExpectedMessages.ExpectedMessageForCatsEq should contain expected strings", testExpectedMessageForCatsEq),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsHash should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsEq should contain expected strings",
+      testExpectedMessageForCatsEq
+    ),
+    example(
+      "OrphanCatsMessages.ExpectedMessageForCatsHash should contain expected strings",
       testExpectedMessageForCatsHash
     ),
     example(
-      "ExpectedMessages.ExpectedMessageForCatsOrder should contain expected strings",
+      "OrphanCatsMessages.ExpectedMessageForCatsOrder should contain expected strings",
       testExpectedMessageForCatsOrder
     ),
   )
 
   def testExpectedMessageForCatsShow: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsShow
+    val message = OrphanCatsMessages.MisingCatsShow
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsShow")(_.contains(_)),
@@ -73,7 +76,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsInvariant: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsInvariant
+    val message = OrphanCatsMessages.MisingCatsInvariant
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsInvariant")(_.contains(_)),
@@ -88,7 +91,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsContravariant: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsContravariant
+    val message = OrphanCatsMessages.MisingCatsContravariant
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsContravariant")(_.contains(_)),
@@ -103,7 +106,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsFunctor: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsFunctor
+    val message = OrphanCatsMessages.MisingCatsFunctor
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsFunctor")(_.contains(_)),
@@ -118,7 +121,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsApplicative: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsApplicative
+    val message = OrphanCatsMessages.MisingCatsApplicative
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsApplicative")(_.contains(_)),
@@ -133,7 +136,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsMonad: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsMonad
+    val message = OrphanCatsMessages.MisingCatsMonad
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsMonad")(_.contains(_)),
@@ -148,7 +151,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsTraverse: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsTraverse
+    val message = OrphanCatsMessages.MisingCatsTraverse
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsTraverse")(_.contains(_)),
@@ -163,7 +166,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsSemigroup: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsSemigroup
+    val message = OrphanCatsMessages.MisingCatsSemigroup
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsSemigroup")(_.contains(_)),
@@ -178,7 +181,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsMonoid: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsMonoid
+    val message = OrphanCatsMessages.MisingCatsMonoid
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsMonoid")(_.contains(_)),
@@ -193,7 +196,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsEq: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsEq
+    val message = OrphanCatsMessages.MisingCatsEq
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsEq")(_.contains(_)),
@@ -208,7 +211,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsHash: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsHash
+    val message = OrphanCatsMessages.MisingCatsHash
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsHash")(_.contains(_)),
@@ -223,7 +226,7 @@ object ExpectedMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsOrder: Result = {
-    val message = ExpectedMessages.ExpectedMessageForCatsOrder
+    val message = OrphanCatsMessages.MisingCatsOrder
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsOrder")(_.contains(_)),


### PR DESCRIPTION
## Close #65: Rename `ExpectedMessages` in `orphan-cats` and its fields

- Rename `ExpectedMessages` to `OrphanCatsMessages`
- Rename `ExpectedMessagesSpec` to `OrphanCatsMessagesSpec`
- Update message references to use `OrphanCatsMessages.MisingCats*` pattern
- Update `codecov.yml`