### PR TITLE
Close #67: Rename `ExpectedMessages` in `orphan-circe` (currently in `orphan-circe-test-without-circe`) and its fields

### DIFF
--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceCodecWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceCodecWithoutCirceSpec.scala
@@ -14,7 +14,7 @@ object CirceCodecWithoutCirceSpec extends Properties {
   )
 
   def testCirceCodec: Result = {
-    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCirceCodec}
+    val expected = s"""error: ${OrphanCirceMessages.MissingCirceCodec}
                       |orphan_instance.OrphanCirceInstances.MyBoxForCodec.circeCodec
                       |                                                   ^""".stripMargin
 

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceDecoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceDecoderWithoutCirceSpec.scala
@@ -14,7 +14,7 @@ object CirceDecoderWithoutCirceSpec extends Properties {
   )
 
   def testCirceDecoder: Result = {
-    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCirceDecoder}
+    val expected = s"""error: ${OrphanCirceMessages.MissingCirceDecoder}
                       |orphan_instance.OrphanCirceInstances.MyBox.circeDecoder
                       |                                           ^""".stripMargin
 

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceEncoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-2/orphan_test/CirceEncoderWithoutCirceSpec.scala
@@ -14,7 +14,7 @@ object CirceEncoderWithoutCirceSpec extends Properties {
   )
 
   def testCirceEncoder: Result = {
-    val expected = s"""error: ${ExpectedMessages.ExpectedMessageForCirceEncoder}
+    val expected = s"""error: ${OrphanCirceMessages.MissingCirceEncoder}
                       |orphan_instance.OrphanCirceInstances.MyBox.circeEncoder
                       |                                           ^""".stripMargin
 

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceCodecWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceCodecWithoutCirceSpec.scala
@@ -15,7 +15,7 @@ object CirceCodecWithoutCirceSpec extends Properties {
   def testCirceCodec: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = ExpectedMessages.ExpectedMessageForCirceCodec
+    val expectedMessage = OrphanCirceMessages.MissingCirceCodec
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceDecoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceDecoderWithoutCirceSpec.scala
@@ -15,7 +15,7 @@ object CirceDecoderWithoutCirceSpec extends Properties {
   def testCirceDecoder: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = ExpectedMessages.ExpectedMessageForCirceDecoder
+    val expectedMessage = OrphanCirceMessages.MissingCirceDecoder
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceEncoderWithoutCirceSpec.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala-3/orphan_test/CirceEncoderWithoutCirceSpec.scala
@@ -15,7 +15,7 @@ object CirceEncoderWithoutCirceSpec extends Properties {
   def testCirceEncoder: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = ExpectedMessages.ExpectedMessageForCirceEncoder
+    val expectedMessage = OrphanCirceMessages.MissingCirceEncoder
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/OrphanCirceMessages.scala
+++ b/modules/orphan-circe-test-without-circe/shared/src/test/scala/orphan_test/OrphanCirceMessages.scala
@@ -3,15 +3,15 @@ package orphan_test
 /** @author Kevin Lee
   * @since 2025-07-28
   */
-object ExpectedMessages {
+object OrphanCirceMessages {
 
-  val ExpectedMessageForCirceEncoder: String =
+  val MissingCirceEncoder: String =
     """Missing an instance of `CirceEncoder` which means you're trying to use io.circe.Encoder, but circe library is missing in your project config. If you want to have an instance of io.circe.Encoder[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
 
-  val ExpectedMessageForCirceDecoder: String =
+  val MissingCirceDecoder: String =
     """Missing an instance of `CirceDecoder` which means you're trying to use io.circe.Decoder, but circe library is missing in your project config. If you want to have an instance of io.circe.Decoder[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
 
-  val ExpectedMessageForCirceCodec: String =
+  val MissingCirceCodec: String =
     """Missing an instance of `CirceCodec` which means you're trying to use io.circe.Codec, but circe library is missing in your project config. If you want to have an instance of io.circe.Codec[A] provided, please add `"io.circe" %% "circe-core" % CIRCE_VERSION` to your libraryDependencies in build.sbt"""
 
 }


### PR DESCRIPTION
## Close #67: Rename `ExpectedMessages` in `orphan-circe` (currently in `orphan-circe-test-without-circe`) and its fields

- Rename `ExpectedMessages` to `OrphanCirceMessages`
- Update message references to use `OrphanCirceMessages.MisingCirce*` pattern