### PR TITLE
orphan v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,26 @@
+## [0.4.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am4) - 2025-08-23
+
+### Changes
+
+* Update `implicitNotFound` message for `OrphanCats.CatsShow` (#60)
+
+  In the message `Show[F[*]]` should be `Show[A]`.
+***
+* Move `ExpectedMessages` to `orphan-cats` and use the messages for `implicitNotFound` (#63)
+  - All fields in `ExpectedMessages`: `val name: String` => `final val name` to make them constants
+***
+* Rename `ExpectedMessages` in `orphan-cats` and its fields (#65)
+  - Rename `ExpectedMessages` to `OrphanCatsMessages`
+  - Rename `ExpectedMessagesSpec` to `OrphanCatsMessagesSpec`
+  - Update message references to use `OrphanCatsMessages.MisingCats*` pattern
+***
+* Rename `ExpectedMessages` in `orphan-circe` and its fields. (#67)
+
+  (It's actually `orphan-circe-test-without-circe`, but it will be moved to `orphan-circe`).
+  - Rename `ExpectedMessages` to `OrphanCirceMessages`
+  - Update message references to use `OrphanCirceMessages.MisingCirce*` pattern
+
+***
+* Move `OrphanCirceMessages` to `orphan-circe` and use the messages for `implicitNotFound` (#69)
+  - Move `OrphanCirceMessages` from `orphan-circe-test-without-circe` to `orphan-circe`
+  - Use `OrphanCirceMessages.Missing*` messages for `implicitNotFound`


### PR DESCRIPTION
# orphan v0.4.0
## [0.4.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am4) - 2025-08-23

### Changes

* Update `implicitNotFound` message for `OrphanCats.CatsShow` (#60)

  In the message `Show[F[*]]` should be `Show[A]`.
***
* Move `ExpectedMessages` to `orphan-cats` and use the messages for `implicitNotFound` (#63)
  - All fields in `ExpectedMessages`: `val name: String` => `final val name` to make them constants
***
* Rename `ExpectedMessages` in `orphan-cats` and its fields (#65)
  - Rename `ExpectedMessages` to `OrphanCatsMessages`
  - Rename `ExpectedMessagesSpec` to `OrphanCatsMessagesSpec`
  - Update message references to use `OrphanCatsMessages.MisingCats*` pattern
***
* Rename `ExpectedMessages` in `orphan-circe` and its fields. (#67)

  (It's actually `orphan-circe-test-without-circe`, but it will be moved to `orphan-circe`).
  - Rename `ExpectedMessages` to `OrphanCirceMessages`
  - Update message references to use `OrphanCirceMessages.MisingCirce*` pattern

***
* Move `OrphanCirceMessages` to `orphan-circe` and use the messages for `implicitNotFound` (#69)
  - Move `OrphanCirceMessages` from `orphan-circe-test-without-circe` to `orphan-circe`
  - Use `OrphanCirceMessages.Missing*` messages for `implicitNotFound`
