### PR TITLE
Close #72: Fix typos in the field names of `OrphanCatsMessages`

### DIFF
--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsApplicativeWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsApplicativeWithoutCatsSpec.scala
@@ -47,7 +47,7 @@ object CatsApplicativeWithoutCatsSpec extends Properties {
   }
 
   def testCatsApplicative: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsApplicative}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsApplicative}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsApplicative
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsContravariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsContravariantWithoutCatsSpec.scala
@@ -63,7 +63,7 @@ object CatsContravariantWithoutCatsSpec extends Properties {
 
   def testCatsContravariant: Result = {
 
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsContravariant}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsContravariant}
                       |orphan_instance.OrphanCatsInstances.MyEncoder.catsContravariant
                       |                                              ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsEqWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsEqWithoutCatsSpec.scala
@@ -39,7 +39,7 @@ object CatsEqWithoutCatsSpec extends Properties {
   }
 
   def testCatsEq: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsEq}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsEq}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsEq
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsFunctorWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsFunctorWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsFunctorWithoutCatsSpec extends Properties {
   }
 
   def testCatsFunctor: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsFunctor}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsFunctor}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsFunctor
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsHashWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsHashWithoutCatsSpec.scala
@@ -49,7 +49,7 @@ object CatsHashWithoutCatsSpec extends Properties {
   }
 
   def testCatsHash: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsHash}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsHash}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsHash
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsInvariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsInvariantWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsInvariantWithoutCatsSpec extends Properties {
   }
 
   def testCatsInvariant: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsInvariant}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsInvariant}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsInvariant
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonadWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonadWithoutCatsSpec.scala
@@ -36,7 +36,7 @@ object CatsMonadWithoutCatsSpec extends Properties {
   }
 
   def testCatsMonad: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsMonad}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsMonad}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsMonad
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonoidWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsMonoidWithoutCatsSpec.scala
@@ -35,7 +35,7 @@ object CatsMonoidWithoutCatsSpec extends Properties {
   }
 
   def testCatsMonoid: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsMonoid}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsMonoid}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsMonoid
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsOrderWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsOrderWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsOrderWithoutCatsSpec extends Properties {
   }
 
   def testCatsOrder: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsOrder}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsOrder}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsOrder
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsSemigroupWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsSemigroupWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsSemigroupWithoutCatsSpec extends Properties {
   }
 
   def testCatsSemigroup: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsSemigroup}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsSemigroup}
                       |orphan_instance.OrphanCatsKernelInstances.MyNum.catsSemigroup
                       |                                                ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsShowWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsShowWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsShowWithoutCatsSpec extends Properties {
   }
 
   def testCatsShow: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsShow}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsShow}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsShow
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsTraverseWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-2/orphan_test/CatsTraverseWithoutCatsSpec.scala
@@ -58,7 +58,7 @@ object CatsTraverseWithoutCatsSpec extends Properties {
   }
 
   def testCatsTraverse: Result = {
-    val expected = s"""error: ${orphan.OrphanCatsMessages.MisingCatsTraverse}
+    val expected = s"""error: ${orphan.OrphanCatsMessages.MissingCatsTraverse}
                       |orphan_instance.OrphanCatsInstances.MyBox.catsTraverse
                       |                                          ^""".stripMargin
 

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsApplicativeWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsApplicativeWithoutCatsSpec.scala
@@ -47,7 +47,7 @@ object CatsApplicativeWithoutCatsSpec extends Properties {
 
   def testCatsApplicative: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsApplicative
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsApplicative
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsContravariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsContravariantWithoutCatsSpec.scala
@@ -63,7 +63,7 @@ object CatsContravariantWithoutCatsSpec extends Properties {
   def testCatsContravariant: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsContravariant
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsContravariant
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsEqWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsEqWithoutCatsSpec.scala
@@ -39,7 +39,7 @@ object CatsEqWithoutCatsSpec extends Properties {
 
   def testCatsEq: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsEq
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsEq
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsFunctorWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsFunctorWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsFunctorWithoutCatsSpec extends Properties {
 
   def testCatsFunctor: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsFunctor
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsFunctor
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsHashWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsHashWithoutCatsSpec.scala
@@ -49,7 +49,7 @@ object CatsHashWithoutCatsSpec extends Properties {
 
   def testCatsHash: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsHash
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsHash
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsInvariantWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsInvariantWithoutCatsSpec.scala
@@ -25,7 +25,7 @@ object CatsInvariantWithoutCatsSpec extends Properties {
 
   def testCatsInvariant: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsInvariant
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsInvariant
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonadWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonadWithoutCatsSpec.scala
@@ -36,7 +36,7 @@ object CatsMonadWithoutCatsSpec extends Properties {
 
   def testCatsMonad: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsMonad
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsMonad
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonoidWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsMonoidWithoutCatsSpec.scala
@@ -36,7 +36,7 @@ object CatsMonoidWithoutCatsSpec extends Properties {
   def testCatsMonoid: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsMonoid
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsMonoid
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsOrderWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsOrderWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsOrderWithoutCatsSpec extends Properties {
 
   def testCatsOrder: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsOrder
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsOrder
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsSemigroupWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsSemigroupWithoutCatsSpec.scala
@@ -28,7 +28,7 @@ object CatsSemigroupWithoutCatsSpec extends Properties {
   def testCatsSemigroup: Result = {
 
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsSemigroup
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsSemigroup
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsShowWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsShowWithoutCatsSpec.scala
@@ -27,7 +27,7 @@ object CatsShowWithoutCatsSpec extends Properties {
 
   def testCatsShow: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsShow
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsShow
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsTraverseWithoutCatsSpec.scala
+++ b/modules/orphan-cats-test-without-cats/shared/src/test/scala-3/orphan_test/CatsTraverseWithoutCatsSpec.scala
@@ -58,7 +58,7 @@ object CatsTraverseWithoutCatsSpec extends Properties {
 
   def testCatsTraverse: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = orphan.OrphanCatsMessages.MisingCatsTraverse
+    val expectedMessage = orphan.OrphanCatsMessages.MissingCatsTraverse
 
     val actual = typeCheckErrors(
       """

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCats.scala
@@ -19,7 +19,7 @@ trait OrphanCats {
 private[orphan] object OrphanCats {
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsShow
+    msg = OrphanCatsMessages.MissingCatsShow
   )
   sealed protected trait CatsShow[F[*]]
   private[OrphanCats] object CatsShow {
@@ -29,7 +29,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsInvariant
+    msg = OrphanCatsMessages.MissingCatsInvariant
   )
   sealed protected trait CatsInvariant[F[*[*]]]
   private[OrphanCats] object CatsInvariant {
@@ -39,7 +39,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsContravariant
+    msg = OrphanCatsMessages.MissingCatsContravariant
   )
   sealed protected trait CatsContravariant[F[*[*]]]
   private[OrphanCats] object CatsContravariant {
@@ -49,7 +49,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsFunctor
+    msg = OrphanCatsMessages.MissingCatsFunctor
   )
   sealed protected trait CatsFunctor[F[*[*]]]
   private[OrphanCats] object CatsFunctor {
@@ -59,7 +59,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsApplicative
+    msg = OrphanCatsMessages.MissingCatsApplicative
   )
   sealed protected trait CatsApplicative[F[*[*]]]
   private[OrphanCats] object CatsApplicative {
@@ -69,7 +69,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsMonad
+    msg = OrphanCatsMessages.MissingCatsMonad
   )
   sealed protected trait CatsMonad[F[*[*]]]
   private[OrphanCats] object CatsMonad {
@@ -79,7 +79,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsTraverse
+    msg = OrphanCatsMessages.MissingCatsTraverse
   )
   sealed protected trait CatsTraverse[F[*[*]]]
   private[OrphanCats] object CatsTraverse {

--- a/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-2/orphan/OrphanCatsKernel.scala
@@ -15,7 +15,7 @@ trait OrphanCatsKernel {
 private[orphan] object OrphanCatsKernel {
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsSemigroup
+    msg = OrphanCatsMessages.MissingCatsSemigroup
   )
   sealed protected trait CatsSemigroup[F[*]]
   private[OrphanCatsKernel] object CatsSemigroup {
@@ -25,7 +25,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsMonoid
+    msg = OrphanCatsMessages.MissingCatsMonoid
   )
   sealed protected trait CatsMonoid[F[*]]
   private[OrphanCatsKernel] object CatsMonoid {
@@ -35,7 +35,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsEq
+    msg = OrphanCatsMessages.MissingCatsEq
   )
   sealed protected trait CatsEq[F[*]]
   private[OrphanCatsKernel] object CatsEq {
@@ -45,7 +45,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsHash
+    msg = OrphanCatsMessages.MissingCatsHash
   )
   sealed protected trait CatsHash[F[*]]
   private[OrphanCatsKernel] object CatsHash {
@@ -55,7 +55,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsOrder
+    msg = OrphanCatsMessages.MissingCatsOrder
   )
   sealed protected trait CatsOrder[F[*]]
   private[OrphanCatsKernel] object CatsOrder {

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -19,7 +19,7 @@ trait OrphanCats {
 private[orphan] object OrphanCats {
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsShow
+    msg = OrphanCatsMessages.MissingCatsShow
   )
   sealed protected trait CatsShow[F[*]]
   private[OrphanCats] object CatsShow {
@@ -29,7 +29,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsInvariant
+    msg = OrphanCatsMessages.MissingCatsInvariant
   )
   sealed protected trait CatsInvariant[F[*[*]]]
   private[OrphanCats] object CatsInvariant {
@@ -39,7 +39,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsContravariant
+    msg = OrphanCatsMessages.MissingCatsContravariant
   )
   sealed protected trait CatsContravariant[F[*[*]]]
   private[OrphanCats] object CatsContravariant {
@@ -49,7 +49,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsFunctor
+    msg = OrphanCatsMessages.MissingCatsFunctor
   )
   sealed protected trait CatsFunctor[F[*[*]]]
   private[OrphanCats] object CatsFunctor {
@@ -59,7 +59,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsApplicative
+    msg = OrphanCatsMessages.MissingCatsApplicative
   )
   sealed protected trait CatsApplicative[F[*[*]]]
   private[OrphanCats] object CatsApplicative {
@@ -69,7 +69,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsMonad
+    msg = OrphanCatsMessages.MissingCatsMonad
   )
   sealed protected trait CatsMonad[F[*[*]]]
   private[OrphanCats] object CatsMonad {
@@ -79,7 +79,7 @@ private[orphan] object OrphanCats {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsTraverse
+    msg = OrphanCatsMessages.MissingCatsTraverse
   )
   sealed protected trait CatsTraverse[F[*[*]]]
   private[OrphanCats] object CatsTraverse {

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -15,7 +15,7 @@ trait OrphanCatsKernel {
 private[orphan] object OrphanCatsKernel {
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsSemigroup
+    msg = OrphanCatsMessages.MissingCatsSemigroup
   )
   sealed protected trait CatsSemigroup[F[*]]
   private[OrphanCatsKernel] object CatsSemigroup {
@@ -25,7 +25,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsMonoid
+    msg = OrphanCatsMessages.MissingCatsMonoid
   )
   sealed protected trait CatsMonoid[F[*]]
   private[OrphanCatsKernel] object CatsMonoid {
@@ -35,7 +35,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsEq
+    msg = OrphanCatsMessages.MissingCatsEq
   )
   sealed protected trait CatsEq[F[*]]
   private[OrphanCatsKernel] object CatsEq {
@@ -45,7 +45,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsHash
+    msg = OrphanCatsMessages.MissingCatsHash
   )
   sealed protected trait CatsHash[F[*]]
   private[OrphanCatsKernel] object CatsHash {
@@ -55,7 +55,7 @@ private[orphan] object OrphanCatsKernel {
   }
 
   @implicitNotFound(
-    msg = OrphanCatsMessages.MisingCatsOrder
+    msg = OrphanCatsMessages.MissingCatsOrder
   )
   sealed protected trait CatsOrder[F[*]]
   private[OrphanCatsKernel] object CatsOrder {

--- a/modules/orphan-cats/shared/src/main/scala/orphan/OrphanCatsMessages.scala
+++ b/modules/orphan-cats/shared/src/main/scala/orphan/OrphanCatsMessages.scala
@@ -7,73 +7,73 @@ package orphan
 object OrphanCatsMessages {
   // scalafix:off DisableSyntax.noFinalVal
 
-  final val MisingCatsShow =
+  final val MissingCatsShow =
     """Missing an instance of `CatsShow` which means you're trying to use cats.Show, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Show[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsInvariant =
+  final val MissingCatsInvariant =
     """Missing an instance of `CatsInvariant` which means you're trying to use cats.Invariant, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Invariant[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsContravariant =
+  final val MissingCatsContravariant =
     """Missing an instance of `CatsContravariant` which means you're trying to use cats.Contravariant, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Contravariant[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsFunctor =
+  final val MissingCatsFunctor =
     """Missing an instance of `CatsFunctor` which means you're trying to use cats.Functor, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Functor[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsApplicative =
+  final val MissingCatsApplicative =
     """Missing an instance of `CatsApplicative` which means you're trying to use cats.Applicative, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Applicative[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsMonad =
+  final val MissingCatsMonad =
     """Missing an instance of `CatsMonad` which means you're trying to use cats.Monad, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Monad[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsTraverse =
+  final val MissingCatsTraverse =
     """Missing an instance of `CatsTraverse` which means you're trying to use cats.Traverse, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.Traverse[F[*]] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsSemigroup =
+  final val MissingCatsSemigroup =
     """Missing an instance of `CatsSemigroup` which means you're trying to use cats.kernel.Semigroup, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Semigroup[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsMonoid =
+  final val MissingCatsMonoid =
     """Missing an instance of `CatsMonoid` which means you're trying to use cats.kernel.Monoid, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Monoid[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsEq =
+  final val MissingCatsEq =
     """Missing an instance of `CatsEq` which means you're trying to use cats.kernel.Eq, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Eq[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsHash =
+  final val MissingCatsHash =
     """Missing an instance of `CatsHash` which means you're trying to use cats.kernel.Hash, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Hash[A] provided, """ +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
 
-  final val MisingCatsOrder =
+  final val MissingCatsOrder =
     """Missing an instance of `CatsOrder` which means you're trying to use cats.kernel.Order, """ +
       """but cats library is missing in your project config. """ +
       """If you want to have an instance of cats.kernel.Order[A] provided, """ +

--- a/modules/orphan-cats/shared/src/test/scala/orphan/OrphanCatsMessagesSpec.scala
+++ b/modules/orphan-cats/shared/src/test/scala/orphan/OrphanCatsMessagesSpec.scala
@@ -61,7 +61,7 @@ object OrphanCatsMessagesSpec extends Properties {
   )
 
   def testExpectedMessageForCatsShow: Result = {
-    val message = OrphanCatsMessages.MisingCatsShow
+    val message = OrphanCatsMessages.MissingCatsShow
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsShow")(_.contains(_)),
@@ -76,7 +76,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsInvariant: Result = {
-    val message = OrphanCatsMessages.MisingCatsInvariant
+    val message = OrphanCatsMessages.MissingCatsInvariant
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsInvariant")(_.contains(_)),
@@ -91,7 +91,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsContravariant: Result = {
-    val message = OrphanCatsMessages.MisingCatsContravariant
+    val message = OrphanCatsMessages.MissingCatsContravariant
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsContravariant")(_.contains(_)),
@@ -106,7 +106,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsFunctor: Result = {
-    val message = OrphanCatsMessages.MisingCatsFunctor
+    val message = OrphanCatsMessages.MissingCatsFunctor
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsFunctor")(_.contains(_)),
@@ -121,7 +121,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsApplicative: Result = {
-    val message = OrphanCatsMessages.MisingCatsApplicative
+    val message = OrphanCatsMessages.MissingCatsApplicative
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsApplicative")(_.contains(_)),
@@ -136,7 +136,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsMonad: Result = {
-    val message = OrphanCatsMessages.MisingCatsMonad
+    val message = OrphanCatsMessages.MissingCatsMonad
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsMonad")(_.contains(_)),
@@ -151,7 +151,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsTraverse: Result = {
-    val message = OrphanCatsMessages.MisingCatsTraverse
+    val message = OrphanCatsMessages.MissingCatsTraverse
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsTraverse")(_.contains(_)),
@@ -166,7 +166,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsSemigroup: Result = {
-    val message = OrphanCatsMessages.MisingCatsSemigroup
+    val message = OrphanCatsMessages.MissingCatsSemigroup
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsSemigroup")(_.contains(_)),
@@ -181,7 +181,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsMonoid: Result = {
-    val message = OrphanCatsMessages.MisingCatsMonoid
+    val message = OrphanCatsMessages.MissingCatsMonoid
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsMonoid")(_.contains(_)),
@@ -196,7 +196,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsEq: Result = {
-    val message = OrphanCatsMessages.MisingCatsEq
+    val message = OrphanCatsMessages.MissingCatsEq
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsEq")(_.contains(_)),
@@ -211,7 +211,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsHash: Result = {
-    val message = OrphanCatsMessages.MisingCatsHash
+    val message = OrphanCatsMessages.MissingCatsHash
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsHash")(_.contains(_)),
@@ -226,7 +226,7 @@ object OrphanCatsMessagesSpec extends Properties {
   }
 
   def testExpectedMessageForCatsOrder: Result = {
-    val message = OrphanCatsMessages.MisingCatsOrder
+    val message = OrphanCatsMessages.MissingCatsOrder
     Result.all(
       List(
         Result.diffNamed("Should contain instance name", message, "CatsOrder")(_.contains(_)),


### PR DESCRIPTION
## Close #72: Fix typos in the field names of `OrphanCatsMessages`

Fix spelling from "Mising" to "Missing" in all constant names:
- `MisingCatsShow` -> `MissingCatsShow`
- `MisingCatsInvariant` -> `MissingCatsInvariant`
- `MisingCatsContravariant` -> `MissingCatsContravariant`
- `MisingCatsFunctor` -> `MissingCatsFunctor`
- `MisingCatsApplicative` -> `MissingCatsApplicative`
- `MisingCatsMonad` -> `MissingCatsMonad`
- `MisingCatsTraverse` -> `MissingCatsTraverse`
- `MisingCatsSemigroup` -> `MissingCatsSemigroup`
- `MisingCatsMonoid` -> `MissingCatsMonoid`
- `MisingCatsEq` -> `MissingCatsEq`
- `MisingCatsHash` -> `MissingCatsHash`
- `MisingCatsOrder` -> `MissingCatsOrder`