### PR TITLE
orphan v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,20 @@
+## [0.5.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am5) - 2025-08-23
+
+### Changes
+
+* Fix typos in the field names of `OrphanCatsMessages` (#72)
+
+  Fixed spelling from "Mising" to "Missing" in all constant names:
+
+  - `MisingCatsShow` -> `MissingCatsShow`
+  - `MisingCatsInvariant` -> `MissingCatsInvariant`
+  - `MisingCatsContravariant` -> `MissingCatsContravariant`
+  - `MisingCatsFunctor` -> `MissingCatsFunctor`
+  - `MisingCatsApplicative` -> `MissingCatsApplicative`
+  - `MisingCatsMonad` -> `MissingCatsMonad`
+  - `MisingCatsTraverse` -> `MissingCatsTraverse`
+  - `MisingCatsSemigroup` -> `MissingCatsSemigroup`
+  - `MisingCatsMonoid` -> `MissingCatsMonoid`
+  - `MisingCatsEq` -> `MissingCatsEq`
+  - `MisingCatsHash` -> `MissingCatsHash`
+  - `MisingCatsOrder` -> `MissingCatsOrder`


### PR DESCRIPTION
# orphan v0.5.0
## [0.5.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am5) - 2025-08-23

### Changes

* Fix typos in the field names of `OrphanCatsMessages` (#72)

  Fixed spelling from "Mising" to "Missing" in all constant names:

  - `MisingCatsShow` -> `MissingCatsShow`
  - `MisingCatsInvariant` -> `MissingCatsInvariant`
  - `MisingCatsContravariant` -> `MissingCatsContravariant`
  - `MisingCatsFunctor` -> `MissingCatsFunctor`
  - `MisingCatsApplicative` -> `MissingCatsApplicative`
  - `MisingCatsMonad` -> `MissingCatsMonad`
  - `MisingCatsTraverse` -> `MissingCatsTraverse`
  - `MisingCatsSemigroup` -> `MissingCatsSemigroup`
  - `MisingCatsMonoid` -> `MissingCatsMonoid`
  - `MisingCatsEq` -> `MissingCatsEq`
  - `MisingCatsHash` -> `MissingCatsHash`
  - `MisingCatsOrder` -> `MissingCatsOrder`
