### PR TITLE
Fix #96: Accessing non-accessible instance causes deprecation compiler-warning due to the recent changes in Scala 3 (3.10)

### DIFF
--- a/.github/workflows/non-accessible-instance-scala-nightly.yml
+++ b/.github/workflows/non-accessible-instance-scala-nightly.yml
@@ -1,0 +1,75 @@
+name: Non-Accessible-Instance-Scala-Nightly
+
+# orphan #96 guard. Builds ONLY the (non-aggregated, non-published) non-accessible-instance
+# modules on Scala 3.3.x / 3.8.4 / the latest 3.10 nightly, on JDK 17 (3.8.4+ require JDK 17+).
+# This is intentionally separate from build.yml/release.yml so it does not change the
+# project-wide minimum Java version (11) or the publish matrix.
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    # Weekly: catch 3.10 nightly drift even without code changes.
+    - cron: "0 6 * * 1"
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'modules/orphan-cats/**'
+      - 'modules/orphan-circe/**'
+      - 'modules/orphan-spray-json/**'
+      - 'modules/**-test-**/**'
+      - 'build.sbt'
+      - '.github/workflows/non-accessible-instance-scala-nightly.yml'
+
+env:
+  GH_JAVA_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+
+jobs:
+
+  non-accessible-instance:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        scala:
+          - "3.3.3"
+          - "3.8.4"
+          - "nightly"
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: temurin
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - name: "Resolve Scala version"
+        id: ver
+        run: |
+          if [ "${{ matrix.scala }}" = "nightly" ]; then
+            V=$(curl -s "https://repo.scala-lang.org/artifactory/maven-nightlies/org/scala-lang/scala3-library_3/maven-metadata.xml" \
+                 | grep -oE '<version>3\.10\.[^<]*-NIGHTLY</version>' | tail -1 \
+                 | sed -E 's/<\/?version>//g')
+            echo "ORPHAN_SCALA_310_NIGHTLY=$V" >> "$GITHUB_ENV"
+            echo "scala_version=$V" >> "$GITHUB_OUTPUT"
+          else
+            echo "scala_version=${{ matrix.scala }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Build orphan #96 non-accessible-instance modules for Scala ${{ steps.ver.outputs.scala_version }} - ${{ github.run_number }}"
+        env:
+          JAVA_OPTS: ${{ env.GH_JAVA_OPTS }}
+          JVM_OPTS: ${{ env.GH_JAVA_OPTS }}
+          SBT_OPTS: ${{ env.GH_JAVA_OPTS }}
+        run: |
+          java -version
+          sbt -v \
+            "clean" \
+            "cleanNonAccessibleInstanceTests" \
+            "++${{ steps.ver.outputs.scala_version }}!" \
+            runNonAccessibleInstanceTests

--- a/build.sbt
+++ b/build.sbt
@@ -198,6 +198,230 @@ lazy val orphanSprayJsonTestWithSprayJson    =
     .dependsOn(orphanSprayJsonTest % props.IncludeTest)
 lazy val orphanSprayJsonTestWithSprayJsonJvm = orphanSprayJsonTestWithSprayJson.jvm
 
+/* ===== orphan #96 "non-accessible instance" guard modules (Scala 3.8.4 / 3.10-nightly) =====
+ * Scala 3 PRs #25516/#25608/#25367 stop inferring implicit/given instances from
+ * non-accessible companion objects. These modules recompile the existing
+ * marker/instance/spec sources under the newer Scala 3 versions (where that change
+ * lands) to prove the markers still resolve. They are NOT aggregated and NOT published.
+ * They disable WartRemover/Tpolecat/semanticdb/scalafix because those per-Scala-version
+ * compiler plugins have no 3.8.4/3.10-nightly artifacts.
+ */
+
+/** Resolve the latest Scala 3.10 nightly. Precedence:
+  *   1. `ORPHAN_SCALA_310_NIGHTLY` env var (CI pins the exact nightly);
+  *   2. the nightlies `maven-metadata.xml` (latest `3.10.x-...-NIGHTLY`);
+  *   3. a pinned known-good fallback (keeps offline/CI deterministic).
+  */
+def latest310Nightly(): String = {
+  val fallback = "3.10.0-RC1-bin-20260621-b3a04ea-NIGHTLY"
+  sys.env.get("ORPHAN_SCALA_310_NIGHTLY").filter(_.nonEmpty).getOrElse {
+    val metadataUrl =
+      "https://repo.scala-lang.org/artifactory/maven-nightlies/org/scala-lang/scala3-library_3/maven-metadata.xml"
+    try {
+      val src = scala.io.Source.fromURL(metadataUrl)("UTF-8")
+
+      val body =
+        try src.mkString
+        finally src.close()
+
+      val versionRe = "<version>(3\\.10\\.[^<]*-NIGHTLY)</version>".r
+      versionRe.findAllMatchIn(body).map(_.group(1)).toList.lastOption.getOrElse(fallback)
+    } catch {
+      case _: Throwable => fallback
+    }
+  }
+}
+
+lazy val nonAccessibleInstanceProps = new {
+  val Scala3Baseline                  = props.Scala3Version // "3.3.3"
+  val Scala384                        = "3.8.4"
+  lazy val Scala310Nightly: String    = latest310Nightly()
+  lazy val ScalaVersions: Seq[String] =
+    Seq(Scala3Baseline, Scala384, Scala310Nightly)
+  val ScalaNightlyResolver            =
+    "scala-nightlies".at("https://repo.scala-lang.org/artifactory/maven-nightlies/")
+}
+
+/** Bare JVM-only test project: does NOT use the module() helper, so none of
+  * WartRemover/Tpolecat/semanticdb/scalafix is injected.
+  */
+def nonAccessibleInstanceModule(id: String): Project =
+  Project(id = id, base = file(s"modules/$id"))
+    .disablePlugins(wartremover.WartRemover, org.typelevel.sbt.tpolecat.TpolecatPlugin)
+    .settings(noPublish)
+    .settings(
+      name := id,
+      fork := true,
+      scalaVersion := nonAccessibleInstanceProps.Scala3Baseline,
+      crossScalaVersions := nonAccessibleInstanceProps.ScalaVersions,
+      semanticdbEnabled := false,
+      scalafixConfig := None,
+      /* kind-projector is required for the markers' `F[*[*]]` syntax (normally supplied by sbt-tpolecat,
+       * which we disable here). The flag was renamed `-Ykind-projector` -> `-Xkind-projector` in 3.4+.
+       * `-no-indent` matches the project's brace style.
+       *
+       * `-deprecation` surfaces the FULL issue-#96 message (otherwise it is summarized as "there were N
+       * deprecation warnings" and `-Wconf`'s `msg=` cannot match it); `-Wconf` then promotes ONLY that
+       * deprecation ("...not accessible here. In Scala 3.10, this implicit will no longer be found") to a
+       * hard ERROR. Without this, on 3.8.4 the bug is only a warning, so the -with test would falsely PASS
+       * even when the marker companion is inaccessible (on the 3.10 nightly it is already a resolution
+       * error). This is what makes the guard actually fail when the fix is missing.
+       */
+      scalacOptions := List("-no-indent", "-deprecation", "-Wconf:msg=not accessible here:e") ++ (
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((3, minor)) if minor <= 3 => List("-Ykind-projector")
+          case _ => List("-Xkind-projector")
+        }
+      ),
+      resolvers += nonAccessibleInstanceProps.ScalaNightlyResolver,
+      libraryDependencies ++= libs.tests.hedgehog.value,
+    )
+
+/** core: markers (Compile) + instances (Test), cats as % Optional. Optional is compile-scope and
+  * NON-propagating, so the -without sibling's typer does not get cats from this module's classpath —
+  * exactly mirroring orphanCats (cats % Optional) + its test instances.
+  */
+lazy val orphanCatsNonAccessibleInstanceCore = nonAccessibleInstanceModule("orphan-cats-non-accessible-instance-core")
+  .settings(
+    libraryDependencies += libs.cats.value % Optional,
+    Compile / unmanagedSourceDirectories ++= List(
+      file("modules") / "orphan-cats" / "shared" / "src" / "main" / "scala-3" / "orphan",
+      file("modules") / "orphan-cats" / "shared" / "src" / "main" / "scala" / "orphan",
+    ),
+    Test / unmanagedSourceDirectories ++= List(
+      file("modules") / "orphan-cats" / "shared" / "src" / "test" / "scala-3" / "orphan_instance",
+    ),
+  )
+
+lazy val orphanCatsNonAccessibleInstanceWith = nonAccessibleInstanceModule("orphan-cats-non-accessible-instance-with")
+  .dependsOn(orphanCatsNonAccessibleInstanceCore % props.IncludeTest)
+  .settings(
+    libraryDependencies += libs.cats.value % Test, // cats present so the with-specs resolve & run
+    Test / unmanagedSourceDirectories ++= List(
+      file("modules") / "orphan-cats-test-with-cats" / "shared" / "src" / "test" / "scala",
+    ),
+  )
+
+lazy val orphanCatsNonAccessibleInstanceWithout =
+  nonAccessibleInstanceModule("orphan-cats-non-accessible-instance-without")
+    .dependsOn(orphanCatsNonAccessibleInstanceCore % props.IncludeTest)
+    .settings(
+      // cats genuinely absent here => the marker's cats.Monad return type fails to load =>
+      // typeCheckErrors sees @implicitNotFound (the degradation contract).
+      excludeDependencies += ExclusionRule(organization = "org.typelevel"),
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-cats-test-without-cats" / "shared" / "src" / "test" / "scala-3",
+      ),
+    )
+
+// circe core: markers (Compile, circe % Optional) + instances (Test). circe instances live in the
+// orphan-circe-test module's MAIN scope; here they are placed in Test so the with/without siblings
+// consume them via test->test (these modules are test-only).
+lazy val orphanCirceNonAccessibleInstanceCore =
+  nonAccessibleInstanceModule("orphan-circe-non-accessible-instance-core")
+    .settings(
+      // core (markers) needs circe-core; the instances additionally use circe-generic's semiauto derivation.
+      libraryDependencies ++= List(
+        libs.circeCore.value    % Optional,
+        libs.circeGeneric.value % Optional,
+      ),
+      Compile / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-circe" / "shared" / "src" / "main" / "scala-3" / "orphan",
+        file("modules") / "orphan-circe" / "shared" / "src" / "main" / "scala" / "orphan",
+      ),
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-circe-test" / "shared" / "src" / "main" / "scala-3" / "orphan_instance",
+      ),
+    )
+
+lazy val orphanCirceNonAccessibleInstanceWith =
+  nonAccessibleInstanceModule("orphan-circe-non-accessible-instance-with")
+    .dependsOn(orphanCirceNonAccessibleInstanceCore % props.IncludeTest)
+    .settings(
+      libraryDependencies ++= List(
+        libs.circeCore.value    % Test,
+        libs.circeGeneric.value % Test,
+        libs.circeLiteral.value % Test,
+        libs.circeParser.value  % Test,
+        libs.circeJawn.value    % Test,
+      ),
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-circe-test-with-circe" / "shared" / "src" / "test" / "scala",
+      ),
+    )
+
+lazy val orphanCirceNonAccessibleInstanceWithout =
+  nonAccessibleInstanceModule("orphan-circe-non-accessible-instance-without")
+    .dependsOn(orphanCirceNonAccessibleInstanceCore % props.IncludeTest)
+    .settings(
+      excludeDependencies += ExclusionRule(organization = "io.circe"),
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-circe-test-without-circe" / "shared" / "src" / "test" / "scala-3",
+      ),
+    )
+
+// spray-json core: markers (Compile, spray-json % Optional) + instances (Test).
+lazy val orphanSprayJsonNonAccessibleInstanceCore =
+  nonAccessibleInstanceModule("orphan-spray-json-non-accessible-instance-core")
+    .settings(
+      libraryDependencies += libs.sprayJson % Optional,
+      Compile / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-spray-json" / "shared" / "src" / "main" / "scala-3" / "orphan",
+        file("modules") / "orphan-spray-json" / "shared" / "src" / "main" / "scala" / "orphan",
+      ),
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-spray-json-test" / "shared" / "src" / "main" / "scala-3" / "orphan_instance",
+      ),
+    )
+
+lazy val orphanSprayJsonNonAccessibleInstanceWith =
+  nonAccessibleInstanceModule("orphan-spray-json-non-accessible-instance-with")
+    .dependsOn(orphanSprayJsonNonAccessibleInstanceCore % props.IncludeTest)
+    .settings(
+      libraryDependencies += libs.sprayJson % Test,
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-spray-json-test-with-spray-json" / "shared" / "src" / "test" / "scala",
+      ),
+    )
+
+lazy val orphanSprayJsonNonAccessibleInstanceWithout =
+  nonAccessibleInstanceModule("orphan-spray-json-non-accessible-instance-without")
+    .dependsOn(orphanSprayJsonNonAccessibleInstanceCore % props.IncludeTest)
+    .settings(
+      excludeDependencies += ExclusionRule(organization = "io.spray"),
+      Test / unmanagedSourceDirectories ++= List(
+        file("modules") / "orphan-spray-json-test-without-spray-json" / "shared" / "src" / "test" / "scala-3",
+      ),
+    )
+
+// Runs ONLY the issue-#96 (non-accessible instance) tests. Cross-build with `+`, e.g.
+//   sbt "++3.8.4!" runNonAccessibleInstanceTests
+addCommandAlias(
+  "runNonAccessibleInstanceTests",
+  Seq(
+    "orphan-cats-non-accessible-instance-with/test",
+    "orphan-cats-non-accessible-instance-without/test",
+    "orphan-circe-non-accessible-instance-with/test",
+    "orphan-circe-non-accessible-instance-without/test",
+    "orphan-spray-json-non-accessible-instance-with/test",
+    "orphan-spray-json-non-accessible-instance-without/test",
+  ).mkString(";", ";", ""),
+)
+addCommandAlias(
+  "cleanNonAccessibleInstanceTests",
+  Seq(
+    "orphan-cats-non-accessible-instance-core/clean",
+    "orphan-cats-non-accessible-instance-with/clean",
+    "orphan-cats-non-accessible-instance-without/clean",
+    "orphan-circe-non-accessible-instance-core/clean",
+    "orphan-circe-non-accessible-instance-with/clean",
+    "orphan-circe-non-accessible-instance-without/clean",
+    "orphan-spray-json-non-accessible-instance-core/clean",
+    "orphan-spray-json-non-accessible-instance-with/clean",
+    "orphan-spray-json-non-accessible-instance-without/clean",
+  ).mkString(";", ";", ""),
+)
+
 lazy val props =
   new {
 

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCats.scala
@@ -22,7 +22,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsShow
   )
   sealed protected trait CatsShow[F[*]]
-  private[OrphanCats] object CatsShow {
+  object CatsShow {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsShow: CatsShow[cats.Show] =
       null // scalafix:ok DisableSyntax.null
@@ -32,7 +32,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsInvariant
   )
   sealed protected trait CatsInvariant[F[*[*]]]
-  private[OrphanCats] object CatsInvariant {
+  object CatsInvariant {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsInvariant: CatsInvariant[cats.Invariant] =
       null // scalafix:ok DisableSyntax.null
@@ -42,7 +42,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsContravariant
   )
   sealed protected trait CatsContravariant[F[*[*]]]
-  private[OrphanCats] object CatsContravariant {
+  object CatsContravariant {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsContravariant: CatsContravariant[cats.Contravariant] =
       null // scalafix:ok DisableSyntax.null
@@ -52,7 +52,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsFunctor
   )
   sealed protected trait CatsFunctor[F[*[*]]]
-  private[OrphanCats] object CatsFunctor {
+  object CatsFunctor {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsFunctor: CatsFunctor[cats.Functor] =
       null // scalafix:ok DisableSyntax.null
@@ -62,7 +62,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsApplicative
   )
   sealed protected trait CatsApplicative[F[*[*]]]
-  private[OrphanCats] object CatsApplicative {
+  object CatsApplicative {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsApplicative: CatsApplicative[cats.Applicative] =
       null // scalafix:ok DisableSyntax.null
@@ -72,7 +72,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsMonad
   )
   sealed protected trait CatsMonad[F[*[*]]]
-  private[OrphanCats] object CatsMonad {
+  object CatsMonad {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsMonad: CatsMonad[cats.Monad] =
       null // scalafix:ok DisableSyntax.null
@@ -82,7 +82,7 @@ private[orphan] object OrphanCats {
     msg = OrphanCatsMessages.MissingCatsTraverse
   )
   sealed protected trait CatsTraverse[F[*[*]]]
-  private[OrphanCats] object CatsTraverse {
+  object CatsTraverse {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsTraverse: CatsTraverse[cats.Traverse] =
       null // scalafix:ok DisableSyntax.null

--- a/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
+++ b/modules/orphan-cats/shared/src/main/scala-3/orphan/OrphanCatsKernel.scala
@@ -18,7 +18,7 @@ private[orphan] object OrphanCatsKernel {
     msg = OrphanCatsMessages.MissingCatsSemigroup
   )
   sealed protected trait CatsSemigroup[F[*]]
-  private[OrphanCatsKernel] object CatsSemigroup {
+  object CatsSemigroup {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsSemigroup: CatsSemigroup[cats.kernel.Semigroup] =
       null // scalafix:ok DisableSyntax.null
@@ -28,7 +28,7 @@ private[orphan] object OrphanCatsKernel {
     msg = OrphanCatsMessages.MissingCatsMonoid
   )
   sealed protected trait CatsMonoid[F[*]]
-  private[OrphanCatsKernel] object CatsMonoid {
+  object CatsMonoid {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsMonoid: CatsMonoid[cats.kernel.Monoid] =
       null // scalafix:ok DisableSyntax.null
@@ -38,7 +38,7 @@ private[orphan] object OrphanCatsKernel {
     msg = OrphanCatsMessages.MissingCatsEq
   )
   sealed protected trait CatsEq[F[*]]
-  private[OrphanCatsKernel] object CatsEq {
+  object CatsEq {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsEq: CatsEq[cats.kernel.Eq] =
       null // scalafix:ok DisableSyntax.null
@@ -48,7 +48,7 @@ private[orphan] object OrphanCatsKernel {
     msg = OrphanCatsMessages.MissingCatsHash
   )
   sealed protected trait CatsHash[F[*]]
-  private[OrphanCatsKernel] object CatsHash {
+  object CatsHash {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsHash: CatsHash[cats.kernel.Hash] =
       null // scalafix:ok DisableSyntax.null
@@ -58,7 +58,7 @@ private[orphan] object OrphanCatsKernel {
     msg = OrphanCatsMessages.MissingCatsOrder
   )
   sealed protected trait CatsOrder[F[*]]
-  private[OrphanCatsKernel] object CatsOrder {
+  object CatsOrder {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCatsOrder: CatsOrder[cats.kernel.Order] =
       null // scalafix:ok DisableSyntax.null

--- a/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
+++ b/modules/orphan-circe/shared/src/main/scala-3/orphan/OrphanCirce.scala
@@ -15,7 +15,7 @@ private[orphan] object OrphanCirce {
     msg = OrphanCirceMessages.MissingCirceEncoder
   )
   sealed protected trait CirceEncoder[F[*]]
-  private[OrphanCirce] object CirceEncoder {
+  object CirceEncoder {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCirceEncoder: CirceEncoder[io.circe.Encoder] =
       null // scalafix:ok DisableSyntax.null
@@ -25,14 +25,14 @@ private[orphan] object OrphanCirce {
     msg = OrphanCirceMessages.MissingCirceDecoder
   )
   sealed protected trait CirceDecoder[F[*]]
-  private[OrphanCirce] object CirceDecoder {
+  object CirceDecoder {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCirceDecoder: CirceDecoder[io.circe.Decoder] =
       null // scalafix:ok DisableSyntax.null
   }
 
-  final abstract private class CirceIsAvailable
-  private object CirceIsAvailable {
+  sealed abstract class CirceIsAvailable
+  object CirceIsAvailable {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getCirceIsAvailable[F[*]: CirceEncoder]: CirceIsAvailable =
       null // scalafix:ok DisableSyntax.null
@@ -42,7 +42,7 @@ private[orphan] object OrphanCirce {
     msg = OrphanCirceMessages.MissingCirceCodec
   )
   sealed protected trait CirceCodec[F[*]]
-  private[OrphanCirce] object CirceCodec {
+  object CirceCodec {
     type CirceCodecEncoderDecoder[A] = io.circe.Codec[A] & io.circe.Encoder[A] & io.circe.Decoder[A]
 
     @SuppressWarnings(Array("org.wartremover.warts.Null"))

--- a/modules/orphan-spray-json/shared/src/main/scala-3/orphan/OrphanSprayJson.scala
+++ b/modules/orphan-spray-json/shared/src/main/scala-3/orphan/OrphanSprayJson.scala
@@ -16,7 +16,7 @@ private[orphan] object OrphanSprayJson {
     msg = OrphanSprayJsonMessages.MissingSprayJsonJsonWriter
   )
   sealed protected trait SprayJsonJsonWriter[F[*]]
-  private[orphan] object SprayJsonJsonWriter {
+  object SprayJsonJsonWriter {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getSprayJsonJsonWriter: SprayJsonJsonWriter[spray.json.JsonWriter] =
       null // scalafix:ok DisableSyntax.null
@@ -26,7 +26,7 @@ private[orphan] object OrphanSprayJson {
     msg = OrphanSprayJsonMessages.MissingSprayJsonJsonReader
   )
   sealed protected trait SprayJsonJsonReader[F[*]]
-  private[orphan] object SprayJsonJsonReader {
+  object SprayJsonJsonReader {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getSprayJsonJsonReader: SprayJsonJsonReader[spray.json.JsonReader] =
       null // scalafix:ok DisableSyntax.null
@@ -36,7 +36,7 @@ private[orphan] object OrphanSprayJson {
     msg = OrphanSprayJsonMessages.MissingSprayJsonJsonFormat
   )
   sealed protected trait SprayJsonJsonFormat[F[*]]
-  private[orphan] object SprayJsonJsonFormat {
+  object SprayJsonJsonFormat {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     final inline given getSprayJsonJsonFormat: SprayJsonJsonFormat[spray.json.JsonFormat] =
       null // scalafix:ok DisableSyntax.null


### PR DESCRIPTION
## Fix #96: Accessing non-accessible instance causes deprecation compiler-warning due to the recent changes in Scala 3 (3.10)

make no-more-orphans marker companions accessible for Scala 3.10

Scala 3 PRs #25516/#25608/#25367 stop inferring given/implicit instances from companion objects that are not accessible at the call site. orphan's marker `given`s live in qualified-private companions (e.g. `private[OrphanCats] object CatsMonad`), so on 3.10, they silently fail to resolve, breaking every downstream instance. The fix must live in orphan since downstream cannot work around it.

Make each inner marker companion `object` `public` (Scala 3 sources only; the change is Scala-3-specific, Scala 2 left untouched), keeping the enclosing `private[orphan] object` and the `sealed protected` traits. Encapsulation is still provided by `sealed` plus the orphan-internal `asInstanceOf` cast, and graceful degradation is preserved because each `given`'s return type still names the optional library type. Covers `orphan-cats` (cats + kernel), `orphan-circe` (also relaxing `CirceIsAvailable` so the `public` `getCirceCodec` can reference it), and `orphan-spray-json`.

Add Scala 3.8.4 / 3.10-nightly guard modules so the breakage is actually caught (the published build pins Scala 3 to 3.3.3 LTS):
- 9 non-aggregated, non-published `*-non-accessible-instance-*` modules that re-use the existing sources with those plugins disabled and their own `crossScalaVersions` (3.10 nightly resolved dynamically, overridable via `ORPHAN_SCALA_310_NIGHTLY`).
- `-Wconf` promotes the #96 deprecation to an error so the guard fails on 3.8.4, not only on 3.10.
- `runNonAccessibleInstanceTests` alias + a separate JDK 17 CI workflow, leaving the project-wide minimum Java and the publish matrix unchanged.