### PR TITLE
orphan v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,31 @@
+## [0.7.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am7) - 2026-06-23
+
+### Bug Fixed
+
+* Fix: Usage of implicit given instance which is not accessible here causes deprecation warning and potential compilation failure
+  (#96) so instances keep resolving on Scala 3.10
+
+  Scala 3 changes (scala/scala3#25516, scala/scala3#25608, scala/scala3#25367) stop inferring `given`/`implicit` instances from companion objects that are not accessible at the call site. orphan's `no-more-orphans` marker `given`s lived in qualified-private companions (e.g. `private[OrphanCats] object CatsMonad`), so they emitted a deprecation warning on Scala `3.8.4` and would **silently fail to resolve** on Scala `3.10`, breaking every downstream instance that depends on them.
+
+  Fix (Scala 3 sources only; the change is Scala-3-specific):
+  - [X] Make each inner marker companion `object` accessible while keeping the enclosing `private[orphan] object` and the `sealed protected` marker traits unchanged
+    - [X] [`orphan-cats`] `OrphanCats` (7 markers) and `OrphanCatsKernel` (5 markers)
+    - [X] [`orphan-circe`] `OrphanCirce` (3 markers), also relaxing `CirceIsAvailable` so the now-accessible `getCirceCodec` can reference it
+    - [X] [`orphan-spray-json`] `OrphanSprayJson` (3 markers)
+
+  Encapsulation is still provided by the `sealed` marker traits plus the orphan-internal `asInstanceOf` cast, and graceful degradation is preserved because each `given`'s return type still names the optional library type.
+
+  This is **binary- and source-compatible** with `0.6.0` (verified with MiMa): the marker companions remain nested inside the `private[orphan]` enclosing object, so they were never part of the public API and downstream usage is unaffected.
+
+### Internal Housekeeping
+
+* Add Scala 3.8.4 / 3.10-nightly guard modules for #96
+
+  The published build pins Scala 3 to `3.3.3` (where the issue does not appear).
+  
+  To prove the markers keep resolving on the newer compilers:
+
+  - [X] Add 9 non-aggregated, non-published `orphan-{cats,circe,spray-json}-non-accessible-instance-{core,with,without}` modules that re-use the existing marker/instance/spec sources with those plugins disabled, with their own `crossScalaVersions` of `3.3.x` / `3.8.4` / `3.10-nightly` (the 3.10 nightly is resolved dynamically, overridable via `ORPHAN_SCALA_310_NIGHTLY`)
+  - [X] Promote the #96 deprecation to a compile error in those modules so the guard fails on Scala `3.8.4` (where it is otherwise only a warning), not only on Scala `3.10`
+  - [X] Add a `runNonAccessibleInstanceTests` sbt command alias to run only these tests
+  - [X] Add a separate JDK 17 CI workflow that builds only the guard modules on Scala `3.3.3` / `3.8.4` / `3.10-nightly`, leaving the project-wide minimum Java version and the publish matrix unchanged


### PR DESCRIPTION
# orphan v0.7.0
## [0.7.0](https://github.com/kevin-lee/orphan/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20milestone%3Am7) - 2026-06-23

### Bug Fixed

* Fix: Usage of implicit given instance which is not accessible here causes deprecation warning and potential compilation failure
  (#96) so instances keep resolving on Scala 3.10

  Scala 3 changes (scala/scala3#25516, scala/scala3#25608, scala/scala3#25367) stop inferring `given`/`implicit` instances from companion objects that are not accessible at the call site. orphan's `no-more-orphans` marker `given`s lived in qualified-private companions (e.g. `private[OrphanCats] object CatsMonad`), so they emitted a deprecation warning on Scala `3.8.4` and would **silently fail to resolve** on Scala `3.10`, breaking every downstream instance that depends on them.

  Fix (Scala 3 sources only; the change is Scala-3-specific):
  - [X] Make each inner marker companion `object` accessible while keeping the enclosing `private[orphan] object` and the `sealed protected` marker traits unchanged
    - [X] [`orphan-cats`] `OrphanCats` (7 markers) and `OrphanCatsKernel` (5 markers)
    - [X] [`orphan-circe`] `OrphanCirce` (3 markers), also relaxing `CirceIsAvailable` so the now-accessible `getCirceCodec` can reference it
    - [X] [`orphan-spray-json`] `OrphanSprayJson` (3 markers)

  Encapsulation is still provided by the `sealed` marker traits plus the orphan-internal `asInstanceOf` cast, and graceful degradation is preserved because each `given`'s return type still names the optional library type.

  This is **binary- and source-compatible** with `0.6.0` (verified with MiMa): the marker companions remain nested inside the `private[orphan]` enclosing object, so they were never part of the public API and downstream usage is unaffected.

### Internal Housekeeping

* Add Scala 3.8.4 / 3.10-nightly guard modules for #96

  The published build pins Scala 3 to `3.3.3` (where the issue does not appear).
  
  To prove the markers keep resolving on the newer compilers:

  - [X] Add 9 non-aggregated, non-published `orphan-{cats,circe,spray-json}-non-accessible-instance-{core,with,without}` modules that re-use the existing marker/instance/spec sources with those plugins disabled, with their own `crossScalaVersions` of `3.3.x` / `3.8.4` / `3.10-nightly` (the 3.10 nightly is resolved dynamically, overridable via `ORPHAN_SCALA_310_NIGHTLY`)
  - [X] Promote the #96 deprecation to a compile error in those modules so the guard fails on Scala `3.8.4` (where it is otherwise only a warning), not only on Scala `3.10`
  - [X] Add a `runNonAccessibleInstanceTests` sbt command alias to run only these tests
  - [X] Add a separate JDK 17 CI workflow that builds only the guard modules on Scala `3.3.3` / `3.8.4` / `3.10-nightly`, leaving the project-wide minimum Java version and the publish matrix unchanged
